### PR TITLE
can now map to interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <properties>
         <junit.version>4.10</junit.version>
         <slf4j.version>1.7.2</slf4j.version>
+        <spring.version>4.1.6.RELEASE</spring.version>
         <!-- Reporting -->
         <maven.cobertura.version>2.4</maven.cobertura.version>
         <maven.javadoc.version>2.10.3</maven.javadoc.version>
@@ -71,6 +72,26 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.5.2</version>
             <scope>test</scope>
+        </dependency>
+        
+        <!-- Expressions -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Used for dynamic creation of bean classes -->

--- a/src/main/java/io/beanmapper/annotations/BeanExpression.java
+++ b/src/main/java/io/beanmapper/annotations/BeanExpression.java
@@ -1,0 +1,16 @@
+package io.beanmapper.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares evaluation expressions.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BeanExpression {
+
+    String value();
+}

--- a/src/main/java/io/beanmapper/strategy/MapStrategyType.java
+++ b/src/main/java/io/beanmapper/strategy/MapStrategyType.java
@@ -23,6 +23,12 @@ public enum MapStrategyType {
             return new MapToClassStrategy(beanMapper, configuration);
         }
     },
+    MAP_TO_INTERFACE() {
+        @Override
+        public MapStrategy generateMapStrategy(BeanMapper beanMapper, Configuration configuration) {
+            return new MapToInterfaceStrategy(beanMapper, configuration);
+        }
+    },
     MAP_TO_INSTANCE() {
         @Override
         public MapStrategy generateMapStrategy(BeanMapper beanMapper, Configuration configuration) {
@@ -40,7 +46,11 @@ public enum MapStrategyType {
         } else if (configuration.getCollectionClass() != null) {
             return MAP_COLLECTION;
         } else if (configuration.getTargetClass() != null) {
-            return MAP_TO_CLASS;
+            if (configuration.getTargetClass().isInterface()) {
+                return MAP_TO_INTERFACE;
+            } else {
+                return MAP_TO_CLASS;
+            }
         } else if (configuration.getTarget() != null) {
             return MAP_TO_INSTANCE;
         } else {

--- a/src/main/java/io/beanmapper/strategy/MapToInterfaceStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToInterfaceStrategy.java
@@ -1,0 +1,90 @@
+package io.beanmapper.strategy;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.annotations.BeanExpression;
+import io.beanmapper.config.Configuration;
+
+import java.lang.reflect.Method;
+
+/**
+ * 
+ *
+ * @author jeroen
+ * @since Apr 21, 2016
+ */
+public class MapToInterfaceStrategy extends MapToInstanceStrategy {
+    
+    public MapToInterfaceStrategy(BeanMapper beanMapper, Configuration configuration) {
+        super(beanMapper, configuration);
+    }
+    
+    @Override
+    public Object map(Object source) {
+        Class targetClass = getConfiguration().getTargetClass();
+        return buildNewProxy(source, targetClass);
+    }
+    
+    private <T> T buildNewProxy(Object instance, Class<T> interfaceClass) {
+        org.springframework.aop.framework.ProxyFactory proxyFactory = new org.springframework.aop.framework.ProxyFactory();
+        proxyFactory.addInterface(interfaceClass);
+        proxyFactory.addAdvisor(new org.springframework.aop.support.DefaultPointcutAdvisor(new AlwaysPointcut(), new MappingInterceptor(instance)));
+        return (T) proxyFactory.getProxy();
+    }
+    
+    public static class AlwaysPointcut extends org.springframework.aop.support.StaticMethodMatcherPointcut {
+        
+        @Override
+        public boolean matches(Method method, Class<?> targetClass) {
+            return true;
+        }
+        
+    }
+    
+    public static class MappingInterceptor implements org.aopalliance.intercept.MethodInterceptor {
+        
+        private final org.springframework.expression.spel.standard.SpelExpressionParser parser;
+        
+        private final Object source;
+        
+        public MappingInterceptor(Object source) {
+            this.source = source;
+            
+            org.springframework.expression.spel.SpelParserConfiguration config = new org.springframework.expression.spel.SpelParserConfiguration(true, true);
+            parser = new org.springframework.expression.spel.standard.SpelExpressionParser(config);
+        }
+
+        @Override
+        public Object invoke(org.aopalliance.intercept.MethodInvocation invocation) throws Throwable {
+            Method method = invocation.getMethod();
+            BeanExpression[] expressions = method.getDeclaredAnnotationsByType(BeanExpression.class);
+            if (expressions.length == 1) {
+                return evaluate(expressions[0].value());
+            } else {
+                return evaluate("#{" + method.getName() + "()}");
+            }
+        }
+
+        private Object evaluate(String expressions) {
+            StringBuilder result = new StringBuilder();
+            for (int index = 0; index < expressions.length(); index++) {
+                String remainder = expressions.substring(index);
+                if (remainder.startsWith("#{") && remainder.contains("}")) {
+                    int endIndex = remainder.indexOf("}");
+                    String rawExpression = remainder.substring(2, endIndex);
+                    result.append(evaluateSingle(rawExpression));
+                    index += endIndex;
+                } else {
+                    result.append(expressions.charAt(index));
+                }
+            }
+            return result.toString();
+        }
+        
+        private Object evaluateSingle(String rawExpression) {
+            org.springframework.expression.Expression expression = parser.parseExpression(rawExpression);
+            return expression.getValue(source);
+        }
+
+    }
+    
+}

--- a/src/main/java/io/beanmapper/strategy/MapToInterfaceStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToInterfaceStrategy.java
@@ -75,6 +75,8 @@ public class MapToInterfaceStrategy extends MapToInstanceStrategy {
                     return evaluateSingle(rawExpression);
                 }
             }
+            
+            // Otherwise concatenate the evaluations in a string value
             return evaluateConcatenated(expressions);
         }
 

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -1,5 +1,8 @@
 package io.beanmapper;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import io.beanmapper.config.BeanMapperBuilder;
 import io.beanmapper.core.converter.impl.LocalDateTimeToLocalDate;
 import io.beanmapper.core.converter.impl.LocalDateToLocalDateTime;
@@ -11,7 +14,15 @@ import io.beanmapper.exceptions.BeanMappingException;
 import io.beanmapper.testmodel.beanAlias.NestedSourceWithAlias;
 import io.beanmapper.testmodel.beanAlias.SourceWithAlias;
 import io.beanmapper.testmodel.beanAlias.TargetWithAlias;
-import io.beanmapper.testmodel.collections.*;
+import io.beanmapper.testmodel.collections.CollectionListSource;
+import io.beanmapper.testmodel.collections.CollectionListTarget;
+import io.beanmapper.testmodel.collections.CollectionListTargetClear;
+import io.beanmapper.testmodel.collections.CollectionMapSource;
+import io.beanmapper.testmodel.collections.CollectionMapTarget;
+import io.beanmapper.testmodel.collections.CollectionSetSource;
+import io.beanmapper.testmodel.collections.CollectionSetTarget;
+import io.beanmapper.testmodel.collections.SourceWithListGetter;
+import io.beanmapper.testmodel.collections.TargetWithListPublicField;
 import io.beanmapper.testmodel.construct.NestedSourceWithoutConstruct;
 import io.beanmapper.testmodel.construct.SourceWithConstruct;
 import io.beanmapper.testmodel.construct.TargetWithoutConstruct;
@@ -30,7 +41,13 @@ import io.beanmapper.testmodel.defaults.TargetWithDefaults;
 import io.beanmapper.testmodel.emptyobject.EmptySource;
 import io.beanmapper.testmodel.emptyobject.EmptyTarget;
 import io.beanmapper.testmodel.emptyobject.NestedEmptyTarget;
-import io.beanmapper.testmodel.encapsulate.*;
+import io.beanmapper.testmodel.encapsulate.Address;
+import io.beanmapper.testmodel.encapsulate.Country;
+import io.beanmapper.testmodel.encapsulate.House;
+import io.beanmapper.testmodel.encapsulate.ResultAddress;
+import io.beanmapper.testmodel.encapsulate.ResultManyToMany;
+import io.beanmapper.testmodel.encapsulate.ResultManyToOne;
+import io.beanmapper.testmodel.encapsulate.ResultOneToMany;
 import io.beanmapper.testmodel.encapsulate.sourceAnnotated.Car;
 import io.beanmapper.testmodel.encapsulate.sourceAnnotated.CarDriver;
 import io.beanmapper.testmodel.encapsulate.sourceAnnotated.Driver;
@@ -62,6 +79,7 @@ import io.beanmapper.testmodel.person.PersonForm;
 import io.beanmapper.testmodel.person.PersonView;
 import io.beanmapper.testmodel.project.CodeProject;
 import io.beanmapper.testmodel.project.CodeProjectResult;
+import io.beanmapper.testmodel.projection.PersonProjection;
 import io.beanmapper.testmodel.publicfields.SourceWithPublicFields;
 import io.beanmapper.testmodel.publicfields.TargetWithPublicFields;
 import io.beanmapper.testmodel.rule.NestedWithRule;
@@ -75,19 +93,24 @@ import io.beanmapper.testmodel.similarsubclasses.DifferentTarget;
 import io.beanmapper.testmodel.similarsubclasses.SimilarSubclass;
 import io.beanmapper.testmodel.tostring.SourceWithNonString;
 import io.beanmapper.testmodel.tostring.TargetWithString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeSet;
+
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 public class BeanMapperTest {
 
@@ -848,6 +871,19 @@ public class BeanMapperTest {
         exception.expect(BeanConversionException.class);
         exception.expectMessage("Could not convert LocalDate to LocalDateTime.");
         beanMapper.map(source, TargetWithDateTime.class);
+    }
+
+    @Test
+    public void sourceToInterfaceWithExpression() {
+        BeanMapper beanMapper = new BeanMapperBuilder().addPackagePrefix(BeanMapper.class).build();
+        
+        Person person = new Person();
+        person.setName("Jan");
+        person.setPlace("Zoetermeer");
+        
+        PersonProjection projection = beanMapper.map(person, PersonProjection.class);
+        Assert.assertEquals("Jan", projection.getName());
+        Assert.assertEquals("Jan Zoetermeer", projection.getNameAndPlace());
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -878,10 +878,12 @@ public class BeanMapperTest {
         BeanMapper beanMapper = new BeanMapperBuilder().addPackagePrefix(BeanMapper.class).build();
         
         Person person = new Person();
+        person.setId(42L);
         person.setName("Jan");
         person.setPlace("Zoetermeer");
         
         PersonProjection projection = beanMapper.map(person, PersonProjection.class);
+        Assert.assertEquals(Long.valueOf(42), projection.getId());
         Assert.assertEquals("Jan", projection.getName());
         Assert.assertEquals("Jan Zoetermeer", projection.getNameAndPlace());
     }

--- a/src/test/java/io/beanmapper/testmodel/projection/PersonProjection.java
+++ b/src/test/java/io/beanmapper/testmodel/projection/PersonProjection.java
@@ -1,0 +1,18 @@
+package io.beanmapper.testmodel.projection;
+
+import io.beanmapper.annotations.BeanExpression;
+
+/**
+ * 
+ *
+ * @author jeroen
+ * @since Apr 21, 2016
+ */
+public interface PersonProjection {
+    
+    String getName();
+    
+    @BeanExpression("#{name} #{place}")
+    String getNameAndPlace();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/projection/PersonProjection.java
+++ b/src/test/java/io/beanmapper/testmodel/projection/PersonProjection.java
@@ -10,6 +10,8 @@ import io.beanmapper.annotations.BeanExpression;
  */
 public interface PersonProjection {
     
+    Long getId();
+
     String getName();
     
     @BeanExpression("#{name} #{place}")


### PR DESCRIPTION
This feature does introduce a (**provided**) dependency between the bean mapper core and spring. I know that this goes against the initial design goal.

A possible solution would be to rename beanmapper-spring to beanmapper-mvc as this library primarly consists of mvc logic anyway. Also the core should dynamically check if spring is on the classpath, rather than throwing class not found exceptions.

---

By calling the map from an object to an interface type you create a 'projection' of the source object. This proxy stays in synch with the actual source object, providing real time data. See the issue for more details.
