### PR TITLE
Fix for concurrency issues in ClassStore and ClassGenerator 

### DIFF
--- a/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
+++ b/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
@@ -1,16 +1,23 @@
 package io.beanmapper.dynclass;
 
+import java.util.Map;
+
 import io.beanmapper.annotations.BeanCollection;
 import io.beanmapper.core.BeanField;
 import io.beanmapper.core.BeanMatchStore;
 import io.beanmapper.core.converter.collections.BeanCollectionInstructions;
-import javassist.*;
+import javassist.CannotCompileException;
+import javassist.ClassClassPath;
+import javassist.ClassMap;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.CtMethod;
+import javassist.NotFoundException;
 import javassist.bytecode.AnnotationsAttribute;
 import javassist.bytecode.ConstPool;
 import javassist.bytecode.annotation.Annotation;
 import javassist.bytecode.annotation.ClassMemberValue;
-
-import java.util.Map;
 
 public class ClassGenerator {
 
@@ -29,7 +36,7 @@ public class ClassGenerator {
         return new GeneratedClass(createClass(baseClass, baseFields, displayNodes));
     }
 
-    private CtClass createClass(Class<?> base, Map<String, BeanField> baseFields, Node displayNodes) throws Exception {
+    private synchronized CtClass createClass(Class<?> base, Map<String, BeanField> baseFields, Node displayNodes) throws Exception {
         CtClass baseClass = classPool.getCtClass(base.getName());
         CtClass dynClass = classPool.makeClass(base.getName() + "Dyn" + ++GENERATED_CLASS_PREFIX);
 

--- a/src/test/java/io/beanmapper/dynclass/AbstractConcurrentTest.java
+++ b/src/test/java/io/beanmapper/dynclass/AbstractConcurrentTest.java
@@ -1,0 +1,21 @@
+package io.beanmapper.dynclass;
+
+/**
+ * Utility test class to spin up threads with a runnable and wait for them to finish. 
+ */
+public abstract class AbstractConcurrentTest {
+
+    protected void run(int threads, Runnable r) throws InterruptedException {
+        Thread[] tr = new Thread[threads];
+        for (int t = 0; t < tr.length; t++) {
+            tr[t] = new Thread(r);
+        }
+        for (int t = 0; t < tr.length; t++) {
+            tr[t].start();
+        }
+        for (int t = 0; t < tr.length; t++) {
+            tr[t].join();
+        }
+    }
+
+}

--- a/src/test/java/io/beanmapper/dynclass/ClassGeneratorTest.java
+++ b/src/test/java/io/beanmapper/dynclass/ClassGeneratorTest.java
@@ -1,0 +1,39 @@
+package io.beanmapper.dynclass;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.beanmapper.dynclass.model.Person;
+
+public class ClassGeneratorTest extends AbstractConcurrentTest {
+
+    @Test
+    public void shouldNotFailConcurrently() throws Exception {
+        final ClassGenerator gen = new ClassGenerator();
+        final List<Exception> results = Collections.synchronizedList(new ArrayList<Exception>());
+        final Runnable r = new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    for (int t = 0; t < 1000; t++) {
+                        gen.createClass(Person.class, Node.createTree(Collections.singletonList("name")));
+                        Thread.yield();
+                    }
+                } catch (Exception ex) {
+                    results.add(ex);
+                }
+            }
+        };
+
+        run(8, r);
+
+        assertTrue("" + results.size(), results.isEmpty()); // Class generation should produce zero exceptions.
+    }
+
+}

--- a/src/test/java/io/beanmapper/dynclass/ClassStoreTest.java
+++ b/src/test/java/io/beanmapper/dynclass/ClassStoreTest.java
@@ -1,0 +1,35 @@
+package io.beanmapper.dynclass;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.beanmapper.dynclass.model.Person;
+
+public class ClassStoreTest extends AbstractConcurrentTest {
+
+    private ClassStore store;
+
+    @Before
+    public void init() {
+        store = new ClassStore();
+    }
+
+    @Test
+    public void shouldCacheThreadSafe() throws InterruptedException {
+        final Set<Class> results = new CopyOnWriteArraySet<Class>();
+        run(8, new Runnable() {
+            @Override
+            public void run() {
+                results.add(store.getOrCreateGeneratedClass(Person.class, Collections.singletonList("name")));
+            }
+        });
+        assertEquals(1, results.size()); // A thread safe implementation should return one class.
+    }
+
+}


### PR DESCRIPTION
by adding some synchronization. 

The shared static fields `CACHE` and `GENERATED_CLASS_PREFIX` were potentially accessed concurrently; for example when two requests at the same time want a downsized result. I've added two unit tests to prove the fix/fault. If you want to see the tests fail, just remove the synchronized blocks out of `ClassStore` and `ClassGenerator`.