### PR TITLE
@BeanParent, to set a target parent on a target child

### DIFF
--- a/src/main/java/io/beanmapper/annotations/BeanParent.java
+++ b/src/main/java/io/beanmapper/annotations/BeanParent.java
@@ -1,0 +1,16 @@
+package io.beanmapper.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When a target-side property needs to become the value of its parent, it must be annotated with
+ * @BeanParent. The annotation works both on the source and target sides. If the annotation is set,
+ * no regular mapping will take place.
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BeanParent {
+}

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -3,7 +3,6 @@ package io.beanmapper.config;
 import io.beanmapper.BeanMapper;
 import io.beanmapper.core.constructor.BeanInitializer;
 import io.beanmapper.core.converter.BeanConverter;
-import io.beanmapper.core.converter.BeanMapperAware;
 import io.beanmapper.core.converter.collections.CollectionListConverter;
 import io.beanmapper.core.converter.collections.CollectionMapConverter;
 import io.beanmapper.core.converter.collections.CollectionSetConverter;
@@ -113,38 +112,35 @@ public class BeanMapperBuilder {
     public BeanMapper build() {
         BeanMapper beanMapper = new BeanMapper(configuration);
         // Custom bean converters must be registered before default ones
-        addCustomConverters(beanMapper);
+        addCustomConverters();
         if (configuration.isAddDefaultConverters()) {
-            addDefaultConverters(beanMapper);
+            addDefaultConverters();
         }
         return beanMapper;
     }
 
-    private void addCustomConverters(BeanMapper beanMapper) {
+    private void addCustomConverters() {
         for (BeanConverter customBeanConverter : customBeanConverters) {
-            addConverter(beanMapper, customBeanConverter);
+            attachConverter(customBeanConverter);
         }
     }
 
-    private void addDefaultConverters(BeanMapper beanMapper) {
-        addConverter(beanMapper, new PrimitiveConverter());
-        addConverter(beanMapper, new StringToBooleanConverter());
-        addConverter(beanMapper, new StringToIntegerConverter());
-        addConverter(beanMapper, new StringToLongConverter());
-        addConverter(beanMapper, new StringToBigDecimalConverter());
-        addConverter(beanMapper, new StringToEnumConverter());
-        addConverter(beanMapper, new NumberToNumberConverter());
-        addConverter(beanMapper, new ObjectToStringConverter());
+    private void addDefaultConverters() {
+        attachConverter(new PrimitiveConverter());
+        attachConverter(new StringToBooleanConverter());
+        attachConverter(new StringToIntegerConverter());
+        attachConverter(new StringToLongConverter());
+        attachConverter(new StringToBigDecimalConverter());
+        attachConverter(new StringToEnumConverter());
+        attachConverter(new NumberToNumberConverter());
+        attachConverter(new ObjectToStringConverter());
 
-        addConverter(beanMapper, new CollectionListConverter());
-        addConverter(beanMapper, new CollectionSetConverter());
-        addConverter(beanMapper, new CollectionMapConverter());
+        attachConverter(new CollectionListConverter());
+        attachConverter(new CollectionSetConverter());
+        attachConverter(new CollectionMapConverter());
     }
 
-    private void addConverter(BeanMapper beanMapper, BeanConverter customBeanConverter) {
-        if (customBeanConverter instanceof BeanMapperAware) {
-            ((BeanMapperAware) customBeanConverter).setBeanMapper(beanMapper);
-        }
+    private void attachConverter(BeanConverter customBeanConverter) {
         configuration.addConverter(customBeanConverter);
     }
 

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -100,6 +100,11 @@ public class BeanMapperBuilder {
         return this;
     }
 
+    public BeanMapperBuilder setParent(Object parent) {
+        this.configuration.setParent(parent);
+        return this;
+    }
+
     public BeanMapperBuilder setConverterChoosable(boolean converterChoosable) {
         this.configuration.setConverterChoosable(converterChoosable);
         return this;

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -52,6 +52,14 @@ public interface Configuration {
      */
     Object getTarget();
 
+    /**
+     * The active parent for the field that is currently being mapped. This is always a parent
+     * on the target side of BeanMapper. @BeanParent makes us of this variable to assign to a
+     * field
+     * @return the parent of the active field
+     */
+    Object getParent();
+
     BeanInitializer getBeanInitializer();
 
     SkippingBeanUnproxy getBeanUnproxy();
@@ -155,6 +163,14 @@ public interface Configuration {
      * @param target the target instance to map to
      */
     void setTarget(Object target);
+
+    /**
+     * The active parent for the field that is currently being mapped. This is always a parent
+     * on the target side of BeanMapper. @BeanParent makes us of this variable to assign to a
+     * field
+     * @param parent the parent of the active field
+     */
+    void setParent(Object parent);
 
     /**
      * Used to determine whether the configuration can be reused and modified (Override config)

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -66,6 +66,9 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
+    public Object getParent() { return null; }
+
+    @Override
     public Class getCollectionClass() {
         return null;
     }
@@ -180,6 +183,12 @@ public class CoreConfiguration implements Configuration {
     public void setTarget(Object target) {
         throw new BeanConfigurationOperationNotAllowedException(
                 "Illegal to set a target instance on the Core configuration, works only for override configurations");
+    }
+
+    @Override
+    public void setParent(Object parent) {
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to set a parent instance on the Core configuration, works only for override configurations");
     }
 
     @Override

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -30,6 +30,8 @@ public class OverrideConfiguration implements Configuration {
 
     private Object target;
 
+    private Object parent;
+
     private Class collectionClass;
 
     private boolean converterChoosable = true;
@@ -64,6 +66,11 @@ public class OverrideConfiguration implements Configuration {
     @Override
     public Object getTarget() {
         return target;
+    }
+
+    @Override
+    public Object getParent() {
+        return parent == null ? parentConfiguration.getParent() : parent;
     }
 
     @Override
@@ -168,6 +175,9 @@ public class OverrideConfiguration implements Configuration {
     public void setTarget(Object target) {
         this.target = target;
     }
+
+    @Override
+    public void setParent(Object parent) { this.parent = parent; }
 
     @Override
     public void setConverterChoosable(boolean converterChoosable) {

--- a/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
@@ -43,7 +43,7 @@ public abstract class AbstractBeanConverter<S, T> implements BeanConverter {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public final Object convert(Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public final Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         if (source == null) {
             Check.argument(!targetClass.isPrimitive(), "Cannot convert null into primitive.");
             return null;

--- a/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
@@ -3,6 +3,7 @@
  */
 package io.beanmapper.core.converter;
 
+import io.beanmapper.BeanMapper;
 import io.beanmapper.core.BeanFieldMatch;
 import io.beanmapper.utils.Check;
 import io.beanmapper.utils.Classes;
@@ -18,6 +19,8 @@ public abstract class AbstractBeanConverter<S, T> implements BeanConverter {
     private final Class<?> sourceClass;
     
     private final Class<?> targetClass;
+
+    protected BeanMapper beanMapper;
 
     /**
      * Construct a new bean converter, dynamically resolving the source and target class. 
@@ -43,7 +46,8 @@ public abstract class AbstractBeanConverter<S, T> implements BeanConverter {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public final Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public final Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+        this.beanMapper = beanMapper;
         if (source == null) {
             Check.argument(!targetClass.isPrimitive(), "Cannot convert null into primitive.");
             return null;

--- a/src/main/java/io/beanmapper/core/converter/BeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/BeanConverter.java
@@ -1,5 +1,6 @@
 package io.beanmapper.core.converter;
 
+import io.beanmapper.BeanMapper;
 import io.beanmapper.core.BeanFieldMatch;
 
 /**
@@ -16,7 +17,7 @@ public interface BeanConverter {
      * @param targetClass the desired target type
      * @return the converted source instance
      */
-    Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch);
+    Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch);
 
     /**
      * Determines if the conversion of our source type to a 

--- a/src/main/java/io/beanmapper/core/converter/BeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/BeanConverter.java
@@ -16,7 +16,7 @@ public interface BeanConverter {
      * @param targetClass the desired target type
      * @return the converted source instance
      */
-    Object convert(Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch);
+    Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch);
 
     /**
      * Determines if the conversion of our source type to a 

--- a/src/main/java/io/beanmapper/core/converter/BeanMapperAware.java
+++ b/src/main/java/io/beanmapper/core/converter/BeanMapperAware.java
@@ -11,6 +11,7 @@ import io.beanmapper.BeanMapper;
  *
  * @author Jeroen van Schagen
  * @since Nov 13, 2015
+ * @deprecated As of release v0.4.0, internally solved by passing BeanMapper to BeanConverter.convert
  */
 public interface BeanMapperAware {
     

--- a/src/main/java/io/beanmapper/core/converter/collections/AbstractCollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/AbstractCollectionConverter.java
@@ -4,16 +4,14 @@ import io.beanmapper.BeanMapper;
 import io.beanmapper.annotations.BeanCollectionUsage;
 import io.beanmapper.core.BeanFieldMatch;
 import io.beanmapper.core.converter.BeanConverter;
-import io.beanmapper.core.converter.BeanMapperAware;
 import io.beanmapper.utils.Classes;
 
 import java.util.Collection;
 import java.util.Map;
 
-public abstract class AbstractCollectionConverter<T> implements BeanConverter, BeanMapperAware {
+public abstract class AbstractCollectionConverter<T> implements BeanConverter {
 
     private final Class<?> type;
-    private BeanMapper beanMapper;
     protected abstract T createCollection();
 
     public AbstractCollectionConverter() {
@@ -22,7 +20,7 @@ public abstract class AbstractCollectionConverter<T> implements BeanConverter, B
     }
 
     @Override
-    public T convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public T convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         T sourceCollection = (T) source;
 
         if (beanFieldMatch.getCollectionInstructions() == null) {
@@ -31,17 +29,13 @@ public abstract class AbstractCollectionConverter<T> implements BeanConverter, B
 
         T targetCollection = getTargetCollection(beanFieldMatch);
 
-        BeanMapper wrappedBeanMapper = beanMapper
-                .wrapConfig()
-                .setParent(parent)
-                .build();
         if(targetCollection instanceof Map) {
             for (Object key : ((Map)sourceCollection).keySet()) {
-                ((Map) targetCollection).put(key, convertElement(wrappedBeanMapper, ((Map) sourceCollection).get(key), beanFieldMatch));
+                ((Map) targetCollection).put(key, convertElement(beanMapper, ((Map) sourceCollection).get(key), beanFieldMatch));
             }
         } else {
             for (Object sourceItem : (Collection)sourceCollection) {
-                ((Collection) targetCollection).add(convertElement(wrappedBeanMapper, sourceItem, beanFieldMatch));
+                ((Collection) targetCollection).add(convertElement(beanMapper, sourceItem, beanFieldMatch));
             }
         }
 
@@ -76,9 +70,5 @@ public abstract class AbstractCollectionConverter<T> implements BeanConverter, B
         return targetClass.isAssignableFrom(type);
     }
 
-    @Override
-    public void setBeanMapper(BeanMapper beanMapper) {
-        this.beanMapper = beanMapper;
-    }
 
 }

--- a/src/main/java/io/beanmapper/core/converter/collections/AbstractCollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/AbstractCollectionConverter.java
@@ -22,7 +22,7 @@ public abstract class AbstractCollectionConverter<T> implements BeanConverter, B
     }
 
     @Override
-    public T convert(Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public T convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         T sourceCollection = (T) source;
 
         if (beanFieldMatch.getCollectionInstructions() == null) {
@@ -31,13 +31,17 @@ public abstract class AbstractCollectionConverter<T> implements BeanConverter, B
 
         T targetCollection = getTargetCollection(beanFieldMatch);
 
+        BeanMapper wrappedBeanMapper = beanMapper
+                .wrapConfig()
+                .setParent(parent)
+                .build();
         if(targetCollection instanceof Map) {
             for (Object key : ((Map)sourceCollection).keySet()) {
-                ((Map) targetCollection).put(key, convertElement(((Map) sourceCollection).get(key), beanFieldMatch));
+                ((Map) targetCollection).put(key, convertElement(wrappedBeanMapper, ((Map) sourceCollection).get(key), beanFieldMatch));
             }
         } else {
             for (Object sourceItem : (Collection)sourceCollection) {
-                ((Collection) targetCollection).add(convertElement(sourceItem, beanFieldMatch));
+                ((Collection) targetCollection).add(convertElement(wrappedBeanMapper, sourceItem, beanFieldMatch));
             }
         }
 
@@ -63,7 +67,7 @@ public abstract class AbstractCollectionConverter<T> implements BeanConverter, B
         return targetCollection;
     }
 
-    private Object convertElement(Object source, BeanFieldMatch beanFieldMatch) {
+    private Object convertElement(BeanMapper beanMapper, Object source, BeanFieldMatch beanFieldMatch) {
         return beanMapper.map(source, beanFieldMatch.getCollectionInstructions().getCollectionMapsTo(), true);
     }
 

--- a/src/main/java/io/beanmapper/core/converter/impl/NumberToNumberConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/NumberToNumberConverter.java
@@ -42,7 +42,7 @@ public class NumberToNumberConverter implements BeanConverter, BeanMapperAware {
      * then converting that string back into the target number.
      */
     @Override
-    public Object convert(Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         if (source == null || source.getClass().equals(targetClass) || (beanFieldMatch != null && beanFieldMatch.getSourceClass().equals(targetClass))) {
             return source;
         }

--- a/src/main/java/io/beanmapper/core/converter/impl/NumberToNumberConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/NumberToNumberConverter.java
@@ -6,7 +6,6 @@ package io.beanmapper.core.converter.impl;
 import io.beanmapper.BeanMapper;
 import io.beanmapper.core.BeanFieldMatch;
 import io.beanmapper.core.converter.BeanConverter;
-import io.beanmapper.core.converter.BeanMapperAware;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ import java.util.Set;
  * @author Jeroen van Schagen
  * @since Jun 24, 2015
  */
-public class NumberToNumberConverter implements BeanConverter, BeanMapperAware {
+public class NumberToNumberConverter implements BeanConverter {
     
     private static final Set<Class<?>> PRIMITIVES = new HashSet<Class<?>>();
     
@@ -31,18 +30,13 @@ public class NumberToNumberConverter implements BeanConverter, BeanMapperAware {
     }
 
     /**
-     * Bean mapper, used to delegate conversions.
-     */
-    private BeanMapper beanMapper;
-
-    /**
      * {@inheritDoc}
      * <br>
      * Works by first converting the number into a string and
      * then converting that string back into the target number.
      */
     @Override
-    public Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         if (source == null || source.getClass().equals(targetClass) || (beanFieldMatch != null && beanFieldMatch.getSourceClass().equals(targetClass))) {
             return source;
         }
@@ -62,12 +56,4 @@ public class NumberToNumberConverter implements BeanConverter, BeanMapperAware {
         return Number.class.isAssignableFrom(clazz) || PRIMITIVES.contains(clazz);
     }
     
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setBeanMapper(BeanMapper beanMapper) {
-        this.beanMapper = beanMapper;
-    }
-
 }

--- a/src/main/java/io/beanmapper/core/converter/impl/PrimitiveConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/PrimitiveConverter.java
@@ -3,6 +3,7 @@
  */
 package io.beanmapper.core.converter.impl;
 
+import io.beanmapper.BeanMapper;
 import io.beanmapper.core.BeanFieldMatch;
 import io.beanmapper.core.converter.BeanConverter;
 import io.beanmapper.utils.Check;
@@ -39,7 +40,7 @@ public class PrimitiveConverter implements BeanConverter {
      * {@inheritDoc}
      */
     @Override
-    public Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         Check.argument(source != null, "Cannot convert null into primitive value.");
         return source; // Value will automatically be boxed or unboxed
     }

--- a/src/main/java/io/beanmapper/core/converter/impl/PrimitiveConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/PrimitiveConverter.java
@@ -39,7 +39,7 @@ public class PrimitiveConverter implements BeanConverter {
      * {@inheritDoc}
      */
     @Override
-    public Object convert(Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
+    public Object convert(Object parent, Object source, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
         Check.argument(source != null, "Cannot convert null into primitive value.");
         return source; // Value will automatically be boxed or unboxed
     }

--- a/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
@@ -129,7 +129,11 @@ public abstract class AbstractMapStrategy implements MapStrategy {
         BeanConverter converter = getConverterOptional(valueClass, targetClass);
         if (converter != null) {
             logger.debug(INDENT + converter.getClass().getSimpleName() + ARROW);
-            return converter.convert(beanFieldMatch.getTarget(), value, targetClass, beanFieldMatch);
+            BeanMapper wrappedBeanMapper = beanMapper
+                    .wrapConfig()
+                    .setParent(beanFieldMatch.getTarget())
+                    .build();
+            return converter.convert(wrappedBeanMapper, value, targetClass, beanFieldMatch);
         }
 
         if (targetClass.isAssignableFrom(valueClass)) {

--- a/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
@@ -1,5 +1,6 @@
 package io.beanmapper.strategy;
 
+import io.beanmapper.annotations.BeanParent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +68,7 @@ public abstract class AbstractMapStrategy implements MapStrategy {
      */
     private void copySourceToTarget(BeanFieldMatch beanFieldMatch) {
         Object copyableSource = beanFieldMatch.getSourceObject();
+
         if (copyableSource == null) {
             if (beanFieldMatch.targetHasAnnotation(BeanDefault.class)) {
                 copyableSource = beanFieldMatch.getTargetDefaultValue();
@@ -75,7 +77,13 @@ public abstract class AbstractMapStrategy implements MapStrategy {
             }
         }
 
-        Object convertedValue = convert(copyableSource, beanFieldMatch.getTargetClass(), beanFieldMatch);
+        final Object convertedValue;
+        if (beanFieldMatch.sourceHasAnnotation(BeanParent.class) || beanFieldMatch.targetHasAnnotation(BeanParent.class)) {
+            convertedValue = beanMapper.getConfiguration().getParent();
+        } else {
+            convertedValue = convert(copyableSource, beanFieldMatch.getTargetClass(), beanFieldMatch);
+        }
+
         beanFieldMatch.writeObject(convertedValue);
     }
 
@@ -90,10 +98,14 @@ public abstract class AbstractMapStrategy implements MapStrategy {
         Object target;
         if (encapsulatedSource != null) {
             logger.debug("    {");
+            BeanMapper beanMapper = getBeanMapper()
+                    .wrapConfig()
+                    .setParent(beanFieldMatch.getTarget())
+                    .build();
             if(beanFieldMatch.getTargetObject() == null){
-                target = getBeanMapper().map(encapsulatedSource, beanFieldMatch.getTargetClass());
+                target = beanMapper.map(encapsulatedSource, beanFieldMatch.getTargetClass());
             } else {
-                target = getBeanMapper().map(encapsulatedSource, beanFieldMatch.getTargetObject());
+                target = beanMapper.map(encapsulatedSource, beanFieldMatch.getTargetObject());
             }
             beanFieldMatch.writeObject(target);
             logger.debug("    }");
@@ -117,7 +129,7 @@ public abstract class AbstractMapStrategy implements MapStrategy {
         BeanConverter converter = getConverterOptional(valueClass, targetClass);
         if (converter != null) {
             logger.debug(INDENT + converter.getClass().getSimpleName() + ARROW);
-            return converter.convert(value, targetClass, beanFieldMatch);
+            return converter.convert(beanFieldMatch.getTarget(), value, targetClass, beanFieldMatch);
         }
 
         if (targetClass.isAssignableFrom(valueClass)) {

--- a/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
@@ -20,7 +20,7 @@ public class MapToClassStrategy extends MapToInstanceStrategy {
             Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(source.getClass());
             BeanConverter converter = getConverterOptional(valueClass, targetClass);
             if (converter != null) {
-                return converter.convert(getConfiguration().getParent(), source, targetClass, null);
+                return converter.convert(getBeanMapper(), source, targetClass, null);
             }
         }
 

--- a/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
@@ -20,7 +20,7 @@ public class MapToClassStrategy extends MapToInstanceStrategy {
             Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(source.getClass());
             BeanConverter converter = getConverterOptional(valueClass, targetClass);
             if (converter != null) {
-                return converter.convert(source, targetClass, null);
+                return converter.convert(getConfiguration().getParent(), source, targetClass, null);
             }
         }
 

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -52,6 +52,9 @@ import io.beanmapper.testmodel.numbers.SourceWithDouble;
 import io.beanmapper.testmodel.numbers.TargetWithDouble;
 import io.beanmapper.testmodel.othername.SourceWithOtherName;
 import io.beanmapper.testmodel.othername.TargetWithOtherName;
+import io.beanmapper.testmodel.parent.Player;
+import io.beanmapper.testmodel.parent.PlayerForm;
+import io.beanmapper.testmodel.parent.SkillForm;
 import io.beanmapper.testmodel.parentClass.Project;
 import io.beanmapper.testmodel.parentClass.Source;
 import io.beanmapper.testmodel.parentClass.Target;
@@ -816,6 +819,46 @@ public class BeanMapperTest {
         exception.expect(BeanConversionException.class);
         exception.expectMessage("Could not convert LocalDate to LocalDateTime.");
         beanMapper.map(source, TargetWithDateTime.class);
+    }
+
+    @Test
+    public void beanParentDirectDescendantAnnotationOnSource() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .addPackagePrefix(BeanMapper.class)
+                .build();
+
+        PlayerForm form = new PlayerForm();
+        form.name = "w00t";
+        form.skill = new SkillForm();
+        form.skill.name = "Athletics";
+
+        Player player = beanMapper.map(form, Player.class);
+
+        assertEquals("@BeanParent on source side was not triggered", form.name, player.getSkill().getPlayer1().getName());
+        assertEquals("@BeanParent on target side was not triggered", form.name, player.getSkill().getPlayer2().getName());
+    }
+
+    @Test
+    public void beanParentThroughCollection() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .addPackagePrefix(BeanMapper.class)
+                .build();
+
+        PlayerForm form = new PlayerForm();
+        form.name = "w00t";
+        form.skills = new ArrayList<SkillForm>();
+        form.skills.add(new SkillForm());
+        form.skills.get(0).name = "Athletics";
+        form.skills.add(new SkillForm());
+        form.skills.get(1).name = "Football";
+        form.skills.add(new SkillForm());
+        form.skills.get(2).name = "CLimbing";
+
+        Player player = beanMapper.map(form, Player.class);
+
+        assertEquals(form.name, player.getSkills().get(0).getPlayer1().getName());
+        assertEquals(form.name, player.getSkills().get(1).getPlayer1().getName());
+        assertEquals(form.name, player.getSkills().get(2).getPlayer1().getName());
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/core/converter/AbstractBeanConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/AbstractBeanConverterTest.java
@@ -23,22 +23,22 @@ public class AbstractBeanConverterTest {
     @Test
     public void testConvert() {
         LocalDateTime time = LocalDateTime.now();
-        Assert.assertEquals(time.toLocalDate(), converter.convert(time, LocalDate.class, null));
+        Assert.assertEquals(time.toLocalDate(), converter.convert(null,time, LocalDate.class, null));
     }
     
     @Test
     public void testNullSource() {
-        Assert.assertNull(converter.convert(null, LocalDate.class, null));
+        Assert.assertNull(converter.convert(null,null, LocalDate.class, null));
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidSource() {
-        converter.convert("Test", LocalDate.class, null);
+        converter.convert(null,"Test", LocalDate.class, null);
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidTarget() {
-        converter.convert(LocalDateTime.now(), String.class, null);
+        converter.convert(null,LocalDateTime.now(), String.class, null);
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/NestedSourceClassToNestedTargetClassConverter.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/NestedSourceClassToNestedTargetClassConverter.java
@@ -1,27 +1,15 @@
 package io.beanmapper.core.converter.impl;
 
-import io.beanmapper.BeanMapper;
-import io.beanmapper.core.converter.BeanMapperAware;
 import io.beanmapper.core.converter.SimpleBeanConverter;
 import io.beanmapper.testmodel.converterbetweennestedclasses.NestedSourceClass;
 import io.beanmapper.testmodel.converterbetweennestedclasses.NestedTargetAbstractClass;
 import io.beanmapper.testmodel.converterbetweennestedclasses.NestedTargetClass;
 
-public class NestedSourceClassToNestedTargetClassConverter extends SimpleBeanConverter<NestedSourceClass, NestedTargetAbstractClass> implements BeanMapperAware {
-
-    private BeanMapper beanMapper;
+public class NestedSourceClassToNestedTargetClassConverter extends SimpleBeanConverter<NestedSourceClass, NestedTargetAbstractClass> {
 
     @Override
     protected NestedTargetAbstractClass doConvert(NestedSourceClass source) {
         return beanMapper.map(source, NestedTargetClass.class);
     }
     
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setBeanMapper(BeanMapper beanMapper) {
-        this.beanMapper = beanMapper;
-    }
-
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/ObjectToStringConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/ObjectToStringConverterTest.java
@@ -10,7 +10,7 @@ public class ObjectToStringConverterTest {
     
     @Test
     public void testConvert() {
-        Assert.assertEquals("42", new ObjectToStringConverter().convert(42, String.class, null));
+        Assert.assertEquals("42", new ObjectToStringConverter().convert(null,42, String.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToBigDecimalConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToBigDecimalConverterTest.java
@@ -20,7 +20,7 @@ public class StringToBigDecimalConverterTest {
     
     @Test
     public void testConvert() {
-        Assert.assertEquals("42.24", converter.convert("42.24", BigDecimal.class, null).toString());
+        Assert.assertEquals("42.24", converter.convert(null,"42.24", BigDecimal.class, null).toString());
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToBooleanConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToBooleanConverterTest.java
@@ -19,13 +19,13 @@ public class StringToBooleanConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Boolean.class));
-        Assert.assertEquals(Boolean.TRUE, converter.convert("true", Boolean.class, null));
+        Assert.assertEquals(Boolean.TRUE, converter.convert(null,"true", Boolean.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, boolean.class));
-        Assert.assertEquals(Boolean.TRUE, converter.convert("true", boolean.class, null));
+        Assert.assertEquals(Boolean.TRUE, converter.convert(null,"true", boolean.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToByteConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToByteConverterTest.java
@@ -19,13 +19,13 @@ public class StringToByteConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Byte.class));
-        Assert.assertEquals(Byte.valueOf((byte) 42), converter.convert("42", Byte.class, null));
+        Assert.assertEquals(Byte.valueOf((byte) 42), converter.convert(null,"42", Byte.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, byte.class));
-        Assert.assertEquals(Byte.valueOf((byte) 42), converter.convert("42", byte.class, null));
+        Assert.assertEquals(Byte.valueOf((byte) 42), converter.convert(null,"42", byte.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToDoubleConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToDoubleConverterTest.java
@@ -19,13 +19,13 @@ public class StringToDoubleConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Double.class));
-        Assert.assertEquals(Double.valueOf((double) 42), converter.convert("42", Double.class, null));
+        Assert.assertEquals(Double.valueOf((double) 42), converter.convert(null,"42", Double.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, double.class));
-        Assert.assertEquals(Double.valueOf((double) 42), converter.convert("42", double.class, null));
+        Assert.assertEquals(Double.valueOf((double) 42), converter.convert(null,"42", double.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToEnumConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToEnumConverterTest.java
@@ -18,17 +18,17 @@ public class StringToEnumConverterTest {
     
     @Test
     public void testWithName() {
-        Assert.assertEquals(TestEnum.B, converter.convert("B", TestEnum.class, null));
+        Assert.assertEquals(TestEnum.B, converter.convert(null,"B", TestEnum.class, null));
     }
     
     @Test
     public void testWithEmptyName() {
-        Assert.assertNull(converter.convert("   ", TestEnum.class, null));
+        Assert.assertNull(converter.convert(null,"   ", TestEnum.class, null));
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testWithUnknownName() {
-        converter.convert("?", TestEnum.class, null);
+        converter.convert(null,"?", TestEnum.class, null);
     }
     
     public enum TestEnum {

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToFloatConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToFloatConverterTest.java
@@ -19,13 +19,13 @@ public class StringToFloatConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Float.class));
-        Assert.assertEquals(Float.valueOf((float) 42), converter.convert("42", Float.class, null));
+        Assert.assertEquals(Float.valueOf((float) 42), converter.convert(null,"42", Float.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, float.class));
-        Assert.assertEquals(Float.valueOf((float) 42), converter.convert("42", float.class, null));
+        Assert.assertEquals(Float.valueOf((float) 42), converter.convert(null,"42", float.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToIntegerConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToIntegerConverterTest.java
@@ -19,13 +19,13 @@ public class StringToIntegerConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Integer.class));
-        Assert.assertEquals(Integer.valueOf(42), converter.convert("42", Integer.class, null));
+        Assert.assertEquals(Integer.valueOf(42), converter.convert(null,"42", Integer.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, int.class));
-        Assert.assertEquals(Integer.valueOf(42), converter.convert("42", int.class, null));
+        Assert.assertEquals(Integer.valueOf(42), converter.convert(null,"42", int.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToLongConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToLongConverterTest.java
@@ -19,13 +19,13 @@ public class StringToLongConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Long.class));
-        Assert.assertEquals(Long.valueOf(42), converter.convert("42", Long.class, null));
+        Assert.assertEquals(Long.valueOf(42), converter.convert(null,"42", Long.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, long.class));
-        Assert.assertEquals(Long.valueOf(42), converter.convert("42", long.class, null));
+        Assert.assertEquals(Long.valueOf(42), converter.convert(null,"42", long.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/StringToShortConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/StringToShortConverterTest.java
@@ -19,13 +19,13 @@ public class StringToShortConverterTest {
     @Test
     public void testConvertBoxed() {
         Assert.assertTrue(converter.match(String.class, Short.class));
-        Assert.assertEquals(Short.valueOf((short) 42), converter.convert("42", Short.class, null));
+        Assert.assertEquals(Short.valueOf((short) 42), converter.convert(null, "42", Short.class, null));
     }
     
     @Test
     public void testConvertPrimitive() {
         Assert.assertTrue(converter.match(String.class, short.class));
-        Assert.assertEquals(Short.valueOf((short) 42), converter.convert("42", short.class, null));
+        Assert.assertEquals(Short.valueOf((short) 42), converter.convert(null, "42", short.class, null));
     }
 
 }

--- a/src/test/java/io/beanmapper/testmodel/parent/Player.java
+++ b/src/test/java/io/beanmapper/testmodel/parent/Player.java
@@ -1,0 +1,36 @@
+package io.beanmapper.testmodel.parent;
+
+import java.util.List;
+
+public class Player {
+
+    private String name;
+
+    private Skill skill;
+
+    private List<Skill> skills;
+
+    public Skill getSkill() {
+        return skill;
+    }
+
+    public void setSkill(Skill skill) {
+        this.skill = skill;
+    }
+
+    public List<Skill> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(List<Skill> skills) {
+        this.skills = skills;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/parent/PlayerForm.java
+++ b/src/test/java/io/beanmapper/testmodel/parent/PlayerForm.java
@@ -1,0 +1,16 @@
+package io.beanmapper.testmodel.parent;
+
+import io.beanmapper.annotations.BeanCollection;
+
+import java.util.List;
+
+public class PlayerForm {
+
+    public String name;
+
+    public SkillForm skill;
+
+    @BeanCollection(elementType = Skill.class)
+    public List<SkillForm> skills;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/parent/Skill.java
+++ b/src/test/java/io/beanmapper/testmodel/parent/Skill.java
@@ -1,0 +1,37 @@
+package io.beanmapper.testmodel.parent;
+
+import io.beanmapper.annotations.BeanParent;
+
+public class Skill {
+
+    private String name;
+
+    private Player player1;
+
+    @BeanParent
+    private Player player2;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Player getPlayer1() {
+        return player1;
+    }
+
+    public void setPlayer1(Player player1) {
+        this.player1 = player1;
+    }
+
+    public Player getPlayer2() {
+        return player2;
+    }
+
+    public void setPlayer2(Player player2) {
+        this.player2 = player2;
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/parent/SkillForm.java
+++ b/src/test/java/io/beanmapper/testmodel/parent/SkillForm.java
@@ -1,0 +1,14 @@
+package io.beanmapper.testmodel.parent;
+
+import io.beanmapper.annotations.BeanParent;
+
+public class SkillForm {
+
+    public String name;
+
+    @BeanParent
+    public PlayerForm player1;
+
+    public PlayerForm player2;
+
+}


### PR DESCRIPTION
#66 Introduces the option to mark a field as a recipient for the pare…nt Object. This is especially handy when the ORM (eg, Hibernate) mappings are based on children needing a reference to the parent. A child can then set its reference to the parent during the mapping phase, which reduces manual mapping and -- as an added bonus -- gives you the option to validate before the controller method is hit.

One caveat I'm not too happy with; the Converter interface is changed to make sure the parent can be passed. The reason for this is that mapping a collection is handled by a converter. This converter then calls the BeanMapper.map method. On this last call it needs to pass the parent. Therefore the converter must know what the parent is. Perhaps there is a better solution for this?

The OverrideConfiguration of BeanMapper accepts the parent as a possible field. If the field cannot be found on the current override config, it will scan up the tree until it finds a legit value or hits the Core config.