### PR TITLE
converterChoosable is settable on the CoreConfiguration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+install: mvn install -Dgpg.skip=true
 jdk:
   - oraclejdk8
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,17 @@
         <maven.site.plugin.version>3.3</maven.site.plugin.version>
     </properties>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <dependencies>
     
         <!-- Used for unit testing -->

--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -45,7 +45,6 @@ public class BeanMapper {
 
         return (T) config()
                 .setTargetClass(targetClass)
-                .setConverterChoosable(false)
                 .build()
             .map(source);
     }
@@ -100,12 +99,7 @@ public class BeanMapper {
      */
     @SuppressWarnings("unchecked")
     public <S, T> Collection<T> map(Collection<S> sourceItems, Class<T> targetClass) {
-
-        return (Collection<T>) config()
-                .setTargetClass(targetClass)
-                .setCollectionClass(sourceItems.getClass())
-                .build()
-            .map(sourceItems);
+        return map(sourceItems, targetClass, sourceItems.getClass());
     }
     
     /**
@@ -119,9 +113,9 @@ public class BeanMapper {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public <S, T> Collection<T> map(Collection<S> sourceItems, Class<T> targetClass, Class<? extends Collection> collectionClass) {
-
         return (Collection<T>) config()
                 .setTargetClass(targetClass)
+                .setConverterChoosable(true)
                 .setCollectionClass(collectionClass)
                 .build()
             .map(sourceItems);

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -80,7 +80,7 @@ public interface Configuration {
 
     List<BeanConverter> getBeanConverters();
 
-    boolean isConverterChoosable();
+    Boolean isConverterChoosable();
 
     void withoutDefaultConverters();
 

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -47,6 +47,11 @@ public class CoreConfiguration implements Configuration {
      */
     private List<BeanConverter> beanConverters = new ArrayList<BeanConverter>();
 
+    /**
+     * The value that decides whether a converter may be chosen, or direct mapping has to take place
+     */
+    private Boolean converterChoosable;
+
     private boolean addDefaultConverters = true;
 
     @Override
@@ -104,8 +109,8 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public boolean isConverterChoosable() {
-        return false;
+    public Boolean isConverterChoosable() {
+        return converterChoosable == null ? false : converterChoosable;
     }
 
     @Override
@@ -151,8 +156,7 @@ public class CoreConfiguration implements Configuration {
 
     @Override
     public void setConverterChoosable(boolean converterChoosable) {
-        throw new BeanConfigurationOperationNotAllowedException(
-                "Illegal to set whether the converter is choosable on the Core configuration, works only for override configurations.");
+        this.converterChoosable = converterChoosable;
     }
 
     @Override

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -34,7 +34,7 @@ public class OverrideConfiguration implements Configuration {
 
     private Class collectionClass;
 
-    private boolean converterChoosable = true;
+    private Boolean converterChoosable = null;
 
     public OverrideConfiguration(Configuration configuration) {
         if (configuration == null) {
@@ -107,8 +107,8 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
-    public boolean isConverterChoosable() {
-        return converterChoosable;
+    public Boolean isConverterChoosable() {
+        return converterChoosable == null ? parentConfiguration.isConverterChoosable() : converterChoosable;
     }
 
     @Override

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -861,6 +861,28 @@ public class BeanMapperTest {
         assertEquals(form.name, player.getSkills().get(2).getPlayer1().getName());
     }
 
+    @Test
+    public void numberToNumberInList() {
+        BeanMapper beanMapper = new BeanMapperBuilder().build();
+
+        List<String> numberStrings = new ArrayList<>();
+        numberStrings.add("1");
+
+        List<Integer> numbers = (List<Integer>)beanMapper.map(numberStrings, Integer.class);
+        assertEquals((Integer)1, numbers.get(0));
+    }
+
+    @Test
+    public void numberToNumberInListPassCollectionClass() {
+        BeanMapper beanMapper = new BeanMapperBuilder().build();
+
+        List<String> numberStrings = new ArrayList<>();
+        numberStrings.add("1");
+
+        List<Integer> numbers = (List<Integer>)beanMapper.map(numberStrings, Integer.class, ArrayList.class);
+        assertEquals((Integer)1, numbers.get(0));
+    }
+
     public Person createPerson(String name) {
         Person person = new Person();
         person.setId(1984L);

--- a/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
+++ b/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
@@ -34,12 +34,6 @@ public class BeanMapperBuilderTest {
     }
 
     @Test(expected = BeanConfigurationOperationNotAllowedException.class)
-    public void setConverterChoosableOnCoreThrowsException() {
-        BeanMapperBuilder builder = new BeanMapperBuilder();
-        builder.setConverterChoosable(false);
-    }
-
-    @Test(expected = BeanConfigurationOperationNotAllowedException.class)
     public void setCollectionClassOnCoreThrowsException() {
         BeanMapperBuilder builder = new BeanMapperBuilder();
         builder.setCollectionClass(null);
@@ -54,13 +48,12 @@ public class BeanMapperBuilderTest {
     }
 
     @Test
-    public void isConverterChoosableDefaultForOverrideConfig() {
-        BeanMapper beanMapper = new BeanMapperBuilder().build(); // Core wrapConfig
-        beanMapper = beanMapper
-                .config()
-                .build(); // Override wrapConfig
+    public void isConverterChoosableSettableForCoreConfig() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .setConverterChoosable(true)
+                .build();
         assertTrue(
-                "The Override configuration assumes by default that are likely to be chosen for lower calls",
+                "The Core configuration converterChoosable is settable)",
                 beanMapper.getConfiguration().isConverterChoosable());
     }
 


### PR DESCRIPTION
changed converterChoosable primitive boolean to object Boolean to have tri-state and ability to ask parent configs for the ultimate value.

The boolean values changed; Core > false, Override > true, with no lookup. Logic in BeanMapper set the converterChoosable to false if not required. Now we have Core > null, Override > null. Core returns false if null. There is more of a lookup system through the configurations. List mappers in BeanMapper set the Boolean value explicitly to true. Added two tests to verify this.

End result of this change is that converterChoosable can be set when the starter is used.