### PR TITLE
Added targetCollectionType to @BeanCollection annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper</name>
     <description>Easy-to-use bean mapper for conversion from form to object to view</description>

--- a/src/main/java/io/beanmapper/annotations/BeanCollection.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollection.java
@@ -15,8 +15,9 @@ public @interface BeanCollection {
 
     Class elementType();
 
-    BeanCollectionUsage beanCollectionUsage() default BeanCollectionUsage.REUSE;
+    Class targetCollectionType() default void.class;
 
+    BeanCollectionUsage beanCollectionUsage() default BeanCollectionUsage.REUSE;
 }
 
 // 3 zaken interessant om op te geven:

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -1,15 +1,19 @@
 package io.beanmapper.core;
 
-import io.beanmapper.annotations.*;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import io.beanmapper.annotations.BeanAlias;
+import io.beanmapper.annotations.BeanCollection;
+import io.beanmapper.annotations.BeanIgnore;
+import io.beanmapper.annotations.BeanProperty;
+import io.beanmapper.annotations.BeanUnwrap;
 import io.beanmapper.core.converter.collections.BeanCollectionInstructions;
 import io.beanmapper.core.inspector.PropertyAccessor;
 import io.beanmapper.core.inspector.PropertyAccessors;
 import io.beanmapper.exceptions.BeanMissingPathException;
 import io.beanmapper.exceptions.BeanNoSuchPropertyException;
-
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 public class BeanMatchStore {
 
@@ -111,6 +115,7 @@ public class BeanMatchStore {
         BeanCollectionInstructions collectionInstructions = new BeanCollectionInstructions();
         collectionInstructions.setCollectionMapsTo(beanCollection.elementType());
         collectionInstructions.setBeanCollectionUsage(beanCollection.beanCollectionUsage());
+        collectionInstructions.setTargetCollectionType(beanCollection.targetCollectionType() != void.class ? beanCollection.targetCollectionType() : null);
         beanField.setCollectionInstructions(collectionInstructions);
     }
 

--- a/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
@@ -80,5 +80,4 @@ public abstract class AbstractBeanConverter<S, T> implements BeanConverter {
     protected boolean isMatchingTarget(Class<?> targetClass) {
         return this.targetClass.isAssignableFrom(targetClass);
     }
-    
 }

--- a/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
@@ -6,6 +6,8 @@ public class BeanCollectionInstructions {
 
     private Class collectionMapsTo;
 
+    private Class<?> targetCollectionType;
+
     private BeanCollectionUsage beanCollectionUsage;
 
     public Class getCollectionMapsTo() {
@@ -24,4 +26,11 @@ public class BeanCollectionInstructions {
         this.beanCollectionUsage = beanCollectionUsage;
     }
 
+    public Class<?> getTargetCollectionType() {
+        return targetCollectionType;
+    }
+
+    public void setTargetCollectionType(Class<?> targetCollectionType) {
+        this.targetCollectionType = targetCollectionType;
+    }
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanCollectionUnassignableTargetCollectionTypeException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanCollectionUnassignableTargetCollectionTypeException.java
@@ -1,0 +1,10 @@
+package io.beanmapper.exceptions;
+
+public class BeanCollectionUnassignableTargetCollectionTypeException extends BeanMappingException {
+
+    public static final String ERROR = "Class %s is not assignable from %s.";
+
+    public BeanCollectionUnassignableTargetCollectionTypeException(Class staticClass, Class dynamicClass) {
+        super(String.format(ERROR, staticClass.getSimpleName(), dynamicClass.getSimpleName()));
+    }
+}

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.TreeSet;
 
@@ -17,6 +18,7 @@ import io.beanmapper.core.converter.impl.LocalDateTimeToLocalDate;
 import io.beanmapper.core.converter.impl.LocalDateToLocalDateTime;
 import io.beanmapper.core.converter.impl.NestedSourceClassToNestedTargetClassConverter;
 import io.beanmapper.core.converter.impl.ObjectToStringConverter;
+import io.beanmapper.exceptions.BeanCollectionUnassignableTargetCollectionTypeException;
 import io.beanmapper.exceptions.BeanConversionException;
 import io.beanmapper.exceptions.BeanMappingException;
 import io.beanmapper.testmodel.beanAlias.NestedSourceWithAlias;
@@ -29,6 +31,8 @@ import io.beanmapper.testmodel.collections.CollectionMapSource;
 import io.beanmapper.testmodel.collections.CollectionMapTarget;
 import io.beanmapper.testmodel.collections.CollectionSetSource;
 import io.beanmapper.testmodel.collections.CollectionSetTarget;
+import io.beanmapper.testmodel.collections.CollectionSetTargetIncorrectSubtype;
+import io.beanmapper.testmodel.collections.CollectionSetTargetSpecificSubtype;
 import io.beanmapper.testmodel.collections.SourceWithListGetter;
 import io.beanmapper.testmodel.collections.TargetWithListPublicField;
 import io.beanmapper.testmodel.construct.NestedSourceWithoutConstruct;
@@ -282,9 +286,37 @@ public class BeanMapperTest {
         source.items.add("43");
 
         CollectionSetTarget target = beanMapper.map(source, CollectionSetTarget.class);
+        assertEquals(TreeSet.class, target.items.getClass());
         assertTrue("Must contain 13", target.items.contains(13L));
         assertTrue("Must contain 29", target.items.contains(29L));
         assertTrue("Must contain 43", target.items.contains(43L));
+    }
+
+    @Test
+    public void mapSetCollectionsToSpecificSubType() {
+        CollectionSetSource source = new CollectionSetSource();
+        source.items = new TreeSet<String>();
+        source.items.add("13");
+        source.items.add("29");
+        source.items.add("43");
+
+        CollectionSetTargetSpecificSubtype target = beanMapper.map(source, CollectionSetTargetSpecificSubtype.class);
+        assertEquals(HashSet.class, target.items.getClass());
+        assertTrue("Must contain 13", target.items.contains(13L));
+        assertTrue("Must contain 29", target.items.contains(29L));
+        assertTrue("Must contain 43", target.items.contains(43L));
+    }
+
+
+    @Test(expected = BeanCollectionUnassignableTargetCollectionTypeException.class)
+    public void mapSetCollectionsToIncorrectSubType() {
+        CollectionSetSource source = new CollectionSetSource();
+        source.items = new TreeSet<String>();
+        source.items.add("13");
+        source.items.add("29");
+        source.items.add("43");
+
+        beanMapper.map(source, CollectionSetTargetIncorrectSubtype.class);
     }
 
     @Test

--- a/src/test/java/io/beanmapper/testmodel/collections/CollectionSetTargetIncorrectSubtype.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollectionSetTargetIncorrectSubtype.java
@@ -1,0 +1,16 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.LinkedList;
+import java.util.Set;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class CollectionSetTargetIncorrectSubtype {
+
+    /*
+     * LinkedList is not a subtype of Set
+     * so an error will occur.
+     */
+    @BeanCollection(elementType = Long.class, targetCollectionType = LinkedList.class)
+    public Set<Long> items;
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollectionSetTargetSpecificSubtype.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollectionSetTargetSpecificSubtype.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class CollectionSetTargetSpecificSubtype {
+
+    @BeanCollection(elementType = Long.class, targetCollectionType = HashSet.class)
+    public Set<Long> items;
+}


### PR DESCRIPTION
It is now possible to define a specific target type of
collection in the @BeanCollection annotation. Previously
in the case of a CONSTRUCT operation a TreeSet was always
created, but this doesn't work for classes that do not
implement Comparable. This way the user has a choice what
target collection type to choose.