### PR TITLE
Optional strict handling of BeanMapper mappings

### DIFF
--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -49,6 +49,16 @@ public class BeanMapperBuilder {
         return this;
     }
 
+    public BeanMapperBuilder addBeanPairWithStrictSource(Class<?> sourceClass, Class<?> targetClass) {
+        this.configuration.addBeanPairWithStrictSource(sourceClass, targetClass);
+        return this;
+    }
+
+    public BeanMapperBuilder addBeanPairWithStrictTarget(Class<?> sourceClass, Class<?> targetClass) {
+        this.configuration.addBeanPairWithStrictTarget(sourceClass, targetClass);
+        return this;
+    }
+
     public BeanMapperBuilder addProxySkipClass(Class<?> clazz) {
         this.configuration.addProxySkipClass(clazz);
         return this;
@@ -75,11 +85,13 @@ public class BeanMapperBuilder {
     }
 
     public BeanMapperBuilder downsizeSource(List<String> includeFields) {
+        this.configuration.setApplyStrictMappingConvention(false);
         this.configuration.downsizeSource(includeFields);
         return this;
     }
 
     public BeanMapperBuilder downsizeTarget(List<String> includeFields) {
+        this.configuration.setApplyStrictMappingConvention(false);
         this.configuration.downsizeTarget(includeFields);
         return this;
     }
@@ -109,8 +121,25 @@ public class BeanMapperBuilder {
         return this;
     }
 
+    public BeanMapperBuilder setStrictSourceSuffix(String strictSourceSuffix) {
+        this.configuration.setStrictSourceSuffix(strictSourceSuffix);
+        return this;
+    }
+    
+    public BeanMapperBuilder setStrictTargetSuffix(String strictTargetSuffix) {
+        this.configuration.setStrictTargetSuffix(strictTargetSuffix);
+        return this;
+    }
+    
+    public BeanMapperBuilder setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+        this.configuration.setApplyStrictMappingConvention(applyStrictMappingConvention);
+        return this;
+    }
+    
     public BeanMapper build() {
         BeanMapper beanMapper = new BeanMapper(configuration);
+        // Make sure all strict bean classes have matching properties on the other side
+        configuration.getBeanMatchStore().validateStrictBeanPairs(configuration.getBeanPairs());
         // Custom bean converters must be registered before default ones
         addCustomConverters();
         if (configuration.isAddDefaultConverters()) {

--- a/src/main/java/io/beanmapper/config/BeanPair.java
+++ b/src/main/java/io/beanmapper/config/BeanPair.java
@@ -1,0 +1,50 @@
+package io.beanmapper.config;
+
+public class BeanPair {
+
+    private boolean sourceStrict = false;
+
+    private boolean targetStrict = false;
+
+    private final Class<?> sourceClass;
+
+    private final Class<?> targetClass;
+
+    public BeanPair(Class sourceClass, Class targetClass) {
+        this.sourceClass = sourceClass;
+        this.targetClass = targetClass;
+    }
+
+    public BeanPair withStrictSource() {
+        this.sourceStrict = true;
+        return this;
+    }
+
+    public BeanPair withStrictTarget() {
+        this.targetStrict = true;
+        return this;
+    }
+
+    public boolean isSourceStrict() {
+        return sourceStrict;
+    }
+
+    public boolean isTargetStrict() {
+        return targetStrict;
+    }
+
+    public Class getSourceClass() {
+        return sourceClass;
+    }
+
+    public Class getTargetClass() {
+        return targetClass;
+    }
+
+    public boolean matches(Class<?> currentSourceClass, Class<?> currentTargetClass) {
+        return
+                currentSourceClass.isAssignableFrom(sourceClass) &&
+                currentTargetClass.isAssignableFrom(targetClass);
+    }
+
+}

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -80,18 +80,71 @@ public interface Configuration {
 
     List<BeanConverter> getBeanConverters();
 
+    /**
+     * Returns the entire list of strict bean pairs. The properties on the strict side must
+     * have matching properties on the other, non-strict side.
+     * @return the entire list of strict bean pairs.
+     */
+    List<BeanPair> getBeanPairs();
+
     Boolean isConverterChoosable();
 
     void withoutDefaultConverters();
 
     /**
+     * Returns the classname suffix that determines a source class is to be treated as strict
+     * with regards to mapping. Default is "Form"
+     * @return the source classname suffix for a class to be treated as strict
+     */
+    String getStrictSourceSuffix();
+
+    /**
+     * Returns the classname suffix that determines a target class is to be treated as strict
+     * with regards to mapping. Default is "Result"
+     * @return the target classname suffix for a class to be treated as strict
+     */
+    String getStrictTargetSuffix();
+
+    /**
+     * Determines if strict mapping convention will be applied. This means that if a source
+     * class has the strict source suffix, or a target class has the strict target suffix,
+     * the classes will be treated as if they are strict. This implies that all of their
+     * properties will require matching properties on the other side. Default is true.
+     * @return if true, the strict mapping convention will be applied
+     */
+    Boolean isApplyStrictMappingConvention();
+
+    /**
+     * Returns the collection of strictSourceSuffix, strictTargetSuffix and
+     * applyStrictMappingConvention properties.
+     * @return all properties required for dealing with the strict mapping convention
+     */
+    StrictMappingProperties getStrictMappingProperties();
+
+    /**
      * Add a converter class (must inherit from abstract BeanConverter class) to the beanMapper.
      * On mapping, the beanMapper will check for a suitable converter and use its from and
      * to methods to convert the value of the fields to the correct new data type.
-     * @param converter an instance of the class that contains the conversion method implementations and inherits
-     *                  from the abstract BeanConverter class.
+     * @param converter an instance of the class that contains the conversion method implementations
+     *                  and inherits from the abstract BeanConverter class.
      */
     void addConverter(BeanConverter converter);
+
+    /**
+     * Adds a new pair of classes of which the source is strict. The strict side must match for all
+     * public fields and getter properties.
+     * @param source the source class that must match, also the strict side of the pair
+     * @param target the target class that must match
+     */
+    void addBeanPairWithStrictSource(Class source, Class target);
+
+    /**
+     * Adds a new pair of classes of which the target is strict. The strict side must match for all
+     * public fields and setter properties.
+     * @param source the source class that must match
+     * @param target the target class that must match, also the strict side of the pair
+     */
+    void addBeanPairWithStrictTarget(Class source, Class target);
 
     /**
      * Add classes to skip while unproxying to prevent failing of the BeanMapper while mapping
@@ -180,4 +233,28 @@ public interface Configuration {
     boolean canReuse();
 
     Class determineTargetClass();
+
+    /**
+     * Sets the classname suffix that determines a source class is to be treated as strict
+     * with regards to mapping. Default is "Form"
+     * @param strictSourceSuffix the source classname suffix for a class to be treated as strict
+     */
+    void setStrictSourceSuffix(String strictSourceSuffix);
+
+    /**
+     * Sets the classname suffix that determines a target class is to be treated as strict
+     * with regards to mapping. Default is "Result"
+     * @param strictTargetSuffix the target classname suffix for a class to be treated as strict
+     */
+    void setStrictTargetSuffix(String strictTargetSuffix);
+
+    /**
+     * Determines if strict mapping convention will be applied. This means that if a source
+     * class has the strict source suffix, or a target class has the strict target suffix,
+     * the classes will be treated as if they are strict. This implies that all of their
+     * properties will require matching properties on the other side. Default is true.
+     * @param applyStrictMappingConvention whether the strict mapping convention must be applied
+     */
+    void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention);
+
 }

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -48,11 +48,18 @@ public class CoreConfiguration implements Configuration {
     private List<BeanConverter> beanConverters = new ArrayList<BeanConverter>();
 
     /**
+     * The list of converters that should be checked for conversions.
+     */
+    private List<BeanPair> beanPairs = new ArrayList<BeanPair>();
+
+    /**
      * The value that decides whether a converter may be chosen, or direct mapping has to take place
      */
     private Boolean converterChoosable;
 
     private boolean addDefaultConverters = true;
+
+    private StrictMappingProperties strictMappingProperties = StrictMappingProperties.defaultConfig();
 
     @Override
     public List<String> getDownsizeTarget() { return null; }
@@ -109,6 +116,11 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
+    public List<BeanPair> getBeanPairs() {
+        return this.beanPairs;
+    }
+
+    @Override
     public Boolean isConverterChoosable() {
         return converterChoosable == null ? false : converterChoosable;
     }
@@ -119,8 +131,38 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
+    public String getStrictSourceSuffix() {
+        return strictMappingProperties.getStrictSourceSuffix();
+    }
+
+    @Override
+    public String getStrictTargetSuffix() {
+        return strictMappingProperties.getStrictTargetSuffix();
+    }
+
+    @Override
+    public Boolean isApplyStrictMappingConvention() {
+        return strictMappingProperties.isApplyStrictMappingConvention();
+    }
+
+    @Override
+    public StrictMappingProperties getStrictMappingProperties() {
+        return strictMappingProperties;
+    }
+
+    @Override
     public void addConverter(BeanConverter converter) {
         this.beanConverters.add(converter);
+    }
+
+    @Override
+    public void addBeanPairWithStrictSource(Class source, Class target) {
+        this.beanPairs.add(new BeanPair(source, target).withStrictSource());
+    }
+
+    @Override
+    public void addBeanPairWithStrictTarget(Class source, Class target) {
+        this.beanPairs.add(new BeanPair(source, target).withStrictTarget());
     }
 
     @Override
@@ -204,4 +246,20 @@ public class CoreConfiguration implements Configuration {
     public Class determineTargetClass() {
         return getTargetClass() == null ? getTarget().getClass() : getTargetClass();
     }
+
+    @Override
+    public void setStrictSourceSuffix(String strictSourceSuffix) {
+        this.strictMappingProperties.setStrictSourceSuffix(strictSourceSuffix);
+    }
+
+    @Override
+    public void setStrictTargetSuffix(String strictTargetSuffix) {
+        this.strictMappingProperties.setStrictTargetSuffix(strictTargetSuffix);
+    }
+
+    @Override
+    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+        this.strictMappingProperties.setApplyStrictMappingConvention(applyStrictMappingConvention);
+    }
+
 }

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -21,6 +21,8 @@ public class OverrideConfiguration implements Configuration {
     private List<String> packagePrefixes;
 
     private List<BeanConverter> beanConverters = new ArrayList<BeanConverter>();
+    
+    private List<BeanPair> beanPairs = new ArrayList<BeanPair>();
 
     private List<String> downsizeSourceFields;
 
@@ -35,6 +37,8 @@ public class OverrideConfiguration implements Configuration {
     private Class collectionClass;
 
     private Boolean converterChoosable = null;
+
+    private StrictMappingProperties strictMappingProperties = StrictMappingProperties.emptyConfig();
 
     public OverrideConfiguration(Configuration configuration) {
         if (configuration == null) {
@@ -107,6 +111,14 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
+    public List<BeanPair> getBeanPairs() {
+        List<BeanPair> beanPairs = new ArrayList<BeanPair>();
+        beanPairs.addAll(parentConfiguration.getBeanPairs());
+        beanPairs.addAll(this.beanPairs);
+        return beanPairs;
+    }
+
+    @Override
     public Boolean isConverterChoosable() {
         return converterChoosable == null ? parentConfiguration.isConverterChoosable() : converterChoosable;
     }
@@ -117,8 +129,48 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
+    public String getStrictSourceSuffix() {
+        return strictMappingProperties.getStrictSourceSuffix() == null ?
+                parentConfiguration.getStrictSourceSuffix() :
+                strictMappingProperties.getStrictSourceSuffix();
+    }
+
+    @Override
+    public String getStrictTargetSuffix() {
+        return strictMappingProperties.getStrictTargetSuffix() == null ?
+                parentConfiguration.getStrictTargetSuffix() :
+                strictMappingProperties.getStrictTargetSuffix();
+    }
+
+    @Override
+    public Boolean isApplyStrictMappingConvention() {
+        return strictMappingProperties.isApplyStrictMappingConvention() == null ?
+                parentConfiguration.isApplyStrictMappingConvention() :
+                strictMappingProperties.isApplyStrictMappingConvention();
+    }
+
+    @Override
+    public StrictMappingProperties getStrictMappingProperties() {
+        return new StrictMappingProperties(
+                getStrictSourceSuffix(),
+                getStrictTargetSuffix(),
+                isApplyStrictMappingConvention()
+        );
+    }
+
+    @Override
     public void addConverter(BeanConverter converter) {
         beanConverters.add(converter);
+    }
+
+    @Override
+    public void addBeanPairWithStrictSource(Class source, Class target) {
+        this.beanPairs.add(new BeanPair(source, target).withStrictSource());
+    }
+
+    @Override
+    public void addBeanPairWithStrictTarget(Class source, Class target) {
+        this.beanPairs.add(new BeanPair(source, target).withStrictTarget());
     }
 
     @Override
@@ -193,4 +245,20 @@ public class OverrideConfiguration implements Configuration {
     public Class determineTargetClass() {
         return getTargetClass() == null ? getTarget().getClass() : getTargetClass();
     }
+
+    @Override
+    public void setStrictSourceSuffix(String strictSourceSuffix) {
+        this.strictMappingProperties.setStrictSourceSuffix(strictSourceSuffix);
+    }
+
+    @Override
+    public void setStrictTargetSuffix(String strictTargetSuffix) {
+        this.strictMappingProperties.setStrictTargetSuffix(strictTargetSuffix);
+    }
+
+    @Override
+    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+        this.strictMappingProperties.setApplyStrictMappingConvention(applyStrictMappingConvention);
+    }
+
 }

--- a/src/main/java/io/beanmapper/config/StrictMappingProperties.java
+++ b/src/main/java/io/beanmapper/config/StrictMappingProperties.java
@@ -1,0 +1,88 @@
+package io.beanmapper.config;
+
+public class StrictMappingProperties {
+
+    /**
+     * The classname suffix that determines a source class is to be treated as strict
+     * with regards to mapping.
+     */
+    private String strictSourceSuffix = "Form";
+
+    /**
+     * The classname suffix that determines a target class is to be treated as strict
+     * with regards to mapping.
+     */
+    private String strictTargetSuffix = "Result";
+
+    /**
+     * Determines if strict mapping convention will be applied. This means that if a source
+     * class has the strict source suffix, or a target class has the strict target suffix,
+     * the classes will be treated as if they are strict. This implies that all of their
+     * properties will require matching properties on the other side.
+     */
+    private Boolean applyStrictMappingConvention = true;
+
+    public StrictMappingProperties(
+            String strictSourceSuffix,
+            String strictTargetSuffix,
+            Boolean applyStrictMappingConvention) {
+        this.strictSourceSuffix = strictSourceSuffix;
+        this.strictTargetSuffix = strictTargetSuffix;
+        this.applyStrictMappingConvention = applyStrictMappingConvention;
+    }
+
+    public String getStrictSourceSuffix() {
+        return strictSourceSuffix;
+    }
+
+    public String getStrictTargetSuffix() {
+        return strictTargetSuffix;
+    }
+
+    public Boolean isApplyStrictMappingConvention() {
+        return applyStrictMappingConvention;
+    }
+
+    public void setStrictSourceSuffix(String strictSourceSuffix) {
+        this.strictSourceSuffix = strictSourceSuffix;
+    }
+
+    public void setStrictTargetSuffix(String strictTargetSuffix) {
+        this.strictTargetSuffix = strictTargetSuffix;
+    }
+
+    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+        this.applyStrictMappingConvention = applyStrictMappingConvention;
+    }
+
+    public BeanPair createBeanPair(Class<?> sourceClass, Class<?> targetClass) {
+        BeanPair beanPair = new BeanPair(sourceClass, targetClass);
+        if (!isApplyStrictMappingConvention()) {
+            return beanPair;
+        }
+        if (    strictSourceSuffix != null &&
+                sourceClass.getCanonicalName().endsWith(strictSourceSuffix)) {
+            beanPair = beanPair.withStrictSource();
+        }
+        if (    strictTargetSuffix != null &&
+                targetClass.getCanonicalName().endsWith(strictTargetSuffix)) {
+            beanPair = beanPair.withStrictTarget();
+        }
+        return beanPair;
+    }
+
+    public static StrictMappingProperties defaultConfig() {
+        return new StrictMappingProperties(
+                "Form",
+                "Result",
+                true);
+    }
+
+    public static StrictMappingProperties emptyConfig() {
+        return new StrictMappingProperties(
+                null,
+                null,
+                null);
+    }
+
+}

--- a/src/main/java/io/beanmapper/core/BeanFieldMatch.java
+++ b/src/main/java/io/beanmapper/core/BeanFieldMatch.java
@@ -15,11 +15,12 @@ public class BeanFieldMatch {
     private BeanField targetBeanField;
     private String targetFieldName;
 
-    public BeanFieldMatch(Object source, Object target, BeanField sourceBeanField, BeanField targetBeanField, String targetFieldName, BeanMatch beanMatch) {
+    public BeanFieldMatch(Object source, Object target,
+            MatchedBeanPairField matchedBeanPairField, String targetFieldName, BeanMatch beanMatch) {
         this.source = source;
         this.target = target;
-        this.sourceBeanField = sourceBeanField;
-        this.targetBeanField = targetBeanField;
+        this.sourceBeanField = matchedBeanPairField.getSourceBeanField();
+        this.targetBeanField = matchedBeanPairField.getTargetBeanField();
         this.targetFieldName = targetFieldName;
         this.beanMatch = beanMatch;
     }

--- a/src/main/java/io/beanmapper/core/BeanMatchValidationMessage.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchValidationMessage.java
@@ -1,0 +1,54 @@
+package io.beanmapper.core;
+
+import java.util.List;
+
+import io.beanmapper.config.BeanPair;
+
+public class BeanMatchValidationMessage {
+
+    private boolean logged = false;
+
+    private final List<BeanField> fields;
+
+    private final BeanPair beanPair;
+
+    public BeanMatchValidationMessage(BeanPair beanPair, List<BeanField> fields) {
+        this.beanPair = beanPair;
+        this.fields = fields;
+    }
+
+    public List<BeanField> getFields() {
+        return fields;
+    }
+
+    public Class<?> getSourceClass() {
+        return beanPair.getSourceClass();
+    }
+
+    public Class<?> getTargetClass() {
+        return beanPair.getTargetClass();
+    }
+
+    public boolean isSourceStrict() {
+        return beanPair.isSourceStrict();
+    }
+
+    public boolean isTargetStrict() {
+        return beanPair.isTargetStrict();
+    }
+
+    public Class<?> getStrictClass() {
+        return beanPair.isSourceStrict() ?
+                getSourceClass() :
+                beanPair.isTargetStrict() ? getTargetClass() : null;
+    }
+
+    public boolean isLogged() {
+        return logged;
+    }
+
+    public void setLogged() {
+        logged = true;
+    }
+
+}

--- a/src/main/java/io/beanmapper/core/BeanStrictMappingRequirementsException.java
+++ b/src/main/java/io/beanmapper/core/BeanStrictMappingRequirementsException.java
@@ -1,0 +1,55 @@
+package io.beanmapper.core;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BeanStrictMappingRequirementsException extends RuntimeException {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final List<BeanMatchValidationMessage> validationMessages;
+
+    public BeanStrictMappingRequirementsException(BeanMatchValidationMessage validationMessage) {
+        this(Collections.<BeanMatchValidationMessage>singletonList(validationMessage));
+    }
+
+    public BeanStrictMappingRequirementsException(List<BeanMatchValidationMessage> validationMessages) {
+        this.validationMessages = validationMessages;
+        logErrors(validationMessages);
+    }
+
+    private void logErrors(List<BeanMatchValidationMessage> validationMessages) {
+        for (BeanMatchValidationMessage validationMessage : validationMessages) {
+            if (validationMessage.isLogged()) {
+                continue;
+            }
+            logger.error(
+                    "Missing matching properties for source [" +
+                    validationMessage.getSourceClass().getCanonicalName() +
+                    "]" +
+                    (validationMessage.isSourceStrict() ? "*" : "") +
+                    " > target [" +
+                    validationMessage.getTargetClass().getCanonicalName() +
+                    "]" +
+                    (validationMessage.isTargetStrict() ? "*" : "") +
+                    " for fields:"
+            );
+            for (BeanField field : validationMessage.getFields()) {
+                logger.error(
+                        "> " +
+                        validationMessage.getStrictClass().getSimpleName() +
+                        "." +
+                        field.getProperty().getName());
+            }
+            validationMessage.setLogged();
+        }
+    }
+
+    public List<BeanMatchValidationMessage> getValidationMessages() {
+        return validationMessages;
+    }
+
+}

--- a/src/main/java/io/beanmapper/core/MatchedBeanPairField.java
+++ b/src/main/java/io/beanmapper/core/MatchedBeanPairField.java
@@ -1,0 +1,21 @@
+package io.beanmapper.core;
+
+public class MatchedBeanPairField {
+
+    private final BeanField sourceBeanField;
+
+    private final BeanField targetBeanField;
+
+    public MatchedBeanPairField(BeanField sourceBeanField, BeanField targetBeanField) {
+        this.sourceBeanField = sourceBeanField;
+        this.targetBeanField = targetBeanField;
+    }
+
+    public BeanField getSourceBeanField() {
+        return sourceBeanField;
+    }
+
+    public BeanField getTargetBeanField() {
+        return targetBeanField;
+    }
+}

--- a/src/main/java/io/beanmapper/dynclass/ClassStore.java
+++ b/src/main/java/io/beanmapper/dynclass/ClassStore.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import io.beanmapper.config.StrictMappingProperties;
 import io.beanmapper.exceptions.BeanDynamicClassGenerationException;
 
 public class ClassStore {
@@ -19,7 +20,9 @@ public class ClassStore {
         this.classGenerator = new ClassGenerator();
     }
 
-    public Class<?> getOrCreateGeneratedClass(Class<?> baseClass, List<String> includeFields) {
+    public Class<?> getOrCreateGeneratedClass(
+            Class<?> baseClass, List<String> includeFields,
+            StrictMappingProperties strictMappingProperties) {
         Node displayNodes = Node.createTree(includeFields);
         String baseClassName = baseClass.getName();
         Map<String, Class<?>> generatedClassesForClass = null;
@@ -36,7 +39,10 @@ public class ClassStore {
             Class<?> generatedClass = generatedClassesForClass.get(displayNodes.getKey());
             if (generatedClass == null) {
                 try {
-                    generatedClass = classGenerator.createClass(baseClass, displayNodes).generatedClass;
+                    generatedClass = classGenerator.createClass(
+                            baseClass,
+                            displayNodes,
+                            strictMappingProperties).generatedClass;
                 } catch (Exception err) {
                     throw new BeanDynamicClassGenerationException(err, baseClass, displayNodes.getKey());
                 }

--- a/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
@@ -39,13 +39,19 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
     }
 
     public Object downsizeSource(Object source, List<String> downsizeSourceFields) {
-        final Class dynamicClass = getConfiguration().getClassStore().getOrCreateGeneratedClass(source.getClass(), downsizeSourceFields);
+        final Class dynamicClass = getConfiguration()
+                .getClassStore()
+                .getOrCreateGeneratedClass(
+                        source.getClass(),
+                        downsizeSourceFields,
+                        getConfiguration().getStrictMappingProperties());
         Class<?> targetClass = getConfiguration().getTargetClass();
         Object target = getConfiguration().getTarget();
         Object dynSource = getBeanMapper()
                 .config()
                 .downsizeSource(null)
                 .setTargetClass(dynamicClass)
+//                .setApplyStrictMappingConvention(false)
                 .build()
                 .map(source);
 
@@ -54,16 +60,21 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
                 .wrapConfig()
                 .setTargetClass(targetClass)
                 .setTarget(target)
+//                .setApplyStrictMappingConvention(false)
                 .build()
                 .map(dynSource);
     }
 
     public Object downsizeTarget(Object source, List<String> downsizeTargetFields) {
-        final Class dynamicClass = getConfiguration().getClassStore().getOrCreateGeneratedClass(getConfiguration().determineTargetClass(), downsizeTargetFields);
+        final Class dynamicClass = getConfiguration().getClassStore().getOrCreateGeneratedClass(
+                        getConfiguration().determineTargetClass(),
+                        downsizeTargetFields,
+                        getConfiguration().getStrictMappingProperties());
         return getBeanMapper()
                 .config()
                 .downsizeTarget(null)
                 .setTargetClass(dynamicClass)
+//                .setApplyStrictMappingConvention(false)
                 .build()
                 .map(source);
     }

--- a/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
+++ b/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
@@ -98,6 +98,33 @@ public class BeanMapperBuilderTest {
     }
 
     @Test
+    public void strictMappingConventionForCoreConfig() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .setStrictSourceSuffix("Frm")
+                .setStrictTargetSuffix("Rslt")
+                .build(); // Core wrapConfig
+        Configuration currentConfiguration = beanMapper.getConfiguration();
+        assertEquals("Frm", currentConfiguration.getStrictSourceSuffix());
+        assertEquals("Rslt", currentConfiguration.getStrictTargetSuffix());
+    }
+
+    @Test
+    public void strictMappingConventionForOverrideConfig() {
+        BeanMapper beanMapper = new BeanMapperBuilder().build(); // Core wrapConfig
+        beanMapper = beanMapper.config()
+                .setStrictSourceSuffix("Frm")
+                .build(); // Wrap in an override config
+
+        Configuration currentConfiguration = beanMapper.getConfiguration();
+        assertEquals("Frm",
+                currentConfiguration.getStrictMappingProperties().getStrictSourceSuffix());
+        assertEquals("Result",
+                currentConfiguration.getStrictMappingProperties().getStrictTargetSuffix());
+        assertEquals(true,
+                currentConfiguration.getStrictMappingProperties().isApplyStrictMappingConvention());
+    }
+
+    @Test
     public void cleanConfig() {
         BeanMapper beanMapper = new BeanMapperBuilder().build(); // Core wrapConfig
         beanMapper = wrapAndSetFieldsForSingleRun(beanMapper);

--- a/src/test/java/io/beanmapper/dynclass/ClassGeneratorTest.java
+++ b/src/test/java/io/beanmapper/dynclass/ClassGeneratorTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.beanmapper.config.StrictMappingProperties;
 import io.beanmapper.dynclass.model.Person;
 
 public class ClassGeneratorTest extends AbstractConcurrentTest {
@@ -22,7 +23,10 @@ public class ClassGeneratorTest extends AbstractConcurrentTest {
             public void run() {
                 try {
                     for (int t = 0; t < 1000; t++) {
-                        gen.createClass(Person.class, Node.createTree(Collections.singletonList("name")));
+                        gen.createClass(
+                                Person.class,
+                                Node.createTree(Collections.singletonList("name")),
+                                StrictMappingProperties.defaultConfig());
                         Thread.yield();
                     }
                 } catch (Exception ex) {

--- a/src/test/java/io/beanmapper/dynclass/ClassStoreTest.java
+++ b/src/test/java/io/beanmapper/dynclass/ClassStoreTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.beanmapper.config.StrictMappingProperties;
 import io.beanmapper.dynclass.model.Person;
 
 public class ClassStoreTest extends AbstractConcurrentTest {
@@ -26,7 +27,10 @@ public class ClassStoreTest extends AbstractConcurrentTest {
         run(8, new Runnable() {
             @Override
             public void run() {
-                results.add(store.getOrCreateGeneratedClass(Person.class, Collections.singletonList("name")));
+                results.add(store.getOrCreateGeneratedClass(
+                        Person.class,
+                        Collections.singletonList("name"),
+                        StrictMappingProperties.defaultConfig()));
             }
         });
         assertEquals(1, results.size()); // A thread safe implementation should return one class.

--- a/src/test/java/io/beanmapper/testmodel/strict/SourceAStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/SourceAStrict.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.strict;
+
+public class SourceAStrict {
+    public String name;
+    public String noMatch;
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/SourceBNonStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/SourceBNonStrict.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.strict;
+
+public class SourceBNonStrict {
+    public String name;
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/SourceCStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/SourceCStrict.java
@@ -1,0 +1,15 @@
+package io.beanmapper.testmodel.strict;
+
+import io.beanmapper.annotations.BeanProperty;
+
+public class SourceCStrict {
+
+    public String name;
+    @BeanProperty(name = "stad")
+    public String city;
+
+    public SourceAStrict noMatch1;
+    public SourceBNonStrict noMatch2;
+    public String noMatch3;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/SourceDStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/SourceDStrict.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.strict;
+
+public class SourceDStrict {
+    public String name;
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/SourceEForm.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/SourceEForm.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.strict;
+
+public class SourceEForm {
+
+    public String name;
+    private String city;
+    public String noMatch;
+
+    public String getCity() {
+        return city;
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/SourceF.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/SourceF.java
@@ -1,0 +1,8 @@
+package io.beanmapper.testmodel.strict;
+
+public class SourceF {
+
+    public String name;
+    public String city;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/TargetANonStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/TargetANonStrict.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.strict;
+
+public class TargetANonStrict {
+    public String name;
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/TargetBStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/TargetBStrict.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.strict;
+
+public class TargetBStrict {
+    public String name;
+    public String noMatch;
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/TargetCNonStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/TargetCNonStrict.java
@@ -1,0 +1,8 @@
+package io.beanmapper.testmodel.strict;
+
+public class TargetCNonStrict {
+
+    public String name;
+    public String stad;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/TargetDNonStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/TargetDNonStrict.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.strict;
+
+public class TargetDNonStrict {
+    public String name;
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/TargetE.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/TargetE.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.strict;
+
+public class TargetE {
+
+    public String name;
+    private String city;
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/strict/TargetFResult.java
+++ b/src/test/java/io/beanmapper/testmodel/strict/TargetFResult.java
@@ -1,0 +1,13 @@
+package io.beanmapper.testmodel.strict;
+
+public class TargetFResult {
+
+    public String name;
+    private String city;
+    public String noMatch;
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+}


### PR DESCRIPTION
Issue #75. Added ability to add pairs of classes which must be checked as soon as a BeanMapper instance is created.

As soon as a BeanMapper instance is created (method build on BeanMapperBuilder), it will validate its sets of Bean pairs. The strict side will be verified so that all properties contain matching properties on the other side. If this is not the case, an exception will be thrown. The exception contains information on all the Bean pairs and every mismatching property.

Within BeanMatchStore, there are two routes for a BeanMatch to be created. The main route is the existing one where a match is set up runtime (or reused if already existing). The second route is the pre-bean instantiation validation where are registered strict bean pairs are validated upfront. In both cases the validation is done at the time of BeanMatch construction. The Bean pair validation routine makes use of the underlying exceptions to report them back all at once.

Configuration allows the setting of the strict mapping convention. If this is enabled, any source class with the set suffix (default 'Form') will be considered strict. Same counts for any target class with the set suffix (default 'Result'). This means that the opposing side must have matches for all properties. If these are missing, this will result in an exception. The principle is basically the same as strict bean pairs, but runtime instead of before bean instantiation.

Note that strict mapping convention is disabled for dynamically generated classes (downsizeSource/downsizeTarget), since these concepts rely on the fact that no full match can be supplied.