### PR TITLE
 Strict mapping convention also tries to find matches for private fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to use Beanmapper in your project, simply add the following Maven depen
 <dependency>
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper</name>
     <description>Easy-to-use bean mapper for conversion from form to object to view</description>

--- a/src/main/java/io/beanmapper/core/PropertyMatchupDirection.java
+++ b/src/main/java/io/beanmapper/core/PropertyMatchupDirection.java
@@ -1,0 +1,21 @@
+package io.beanmapper.core;
+
+import io.beanmapper.core.inspector.PropertyAccessor;
+
+public enum PropertyMatchupDirection {
+
+    SOURCE_TO_TARGET {
+        @Override
+        public boolean validAccessor(PropertyAccessor accessor) {
+            return accessor.isReadable();
+        }
+    },
+    TARGET_TO_SOURCE {
+        @Override
+        public boolean validAccessor(PropertyAccessor accessor) {
+            return accessor.isWritable();
+        }
+    };
+
+    public abstract boolean validAccessor(PropertyAccessor accessor);
+}

--- a/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
@@ -55,7 +55,7 @@ public class FieldPropertyAccessor implements PropertyAccessor {
      */
     @Override
     public boolean isReadable() {
-        return true;
+        return Modifier.isPublic(field.getModifiers());
     }
     
     /**

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -123,6 +123,12 @@ import io.beanmapper.testmodel.strict.TargetCNonStrict;
 import io.beanmapper.testmodel.strict.TargetDNonStrict;
 import io.beanmapper.testmodel.strict.TargetE;
 import io.beanmapper.testmodel.strict.TargetFResult;
+import io.beanmapper.testmodel.strictconvention.SCSourceAForm;
+import io.beanmapper.testmodel.strictconvention.SCSourceB;
+import io.beanmapper.testmodel.strictconvention.SCSourceCForm;
+import io.beanmapper.testmodel.strictconvention.SCTargetA;
+import io.beanmapper.testmodel.strictconvention.SCTargetBResult;
+import io.beanmapper.testmodel.strictconvention.SCTargetC;
 import io.beanmapper.testmodel.tostring.SourceWithNonString;
 import io.beanmapper.testmodel.tostring.TargetWithString;
 import mockit.Expectations;
@@ -1042,6 +1048,31 @@ public class BeanMapperTest {
     @Test(expected = BeanStrictMappingRequirementsException.class)
     public void strictMappingConventionForResult() {
         beanMapper.map(new SourceF(), TargetFResult.class);
+    }
+
+    @Test(expected = BeanStrictMappingRequirementsException.class)
+    public void strictMappingConventionMissingMatchForGetter() {
+        beanMapper.map(new SCSourceCForm(), SCTargetC.class);
+    }
+
+    @Test
+    public void strictMappingConventionWithPrivateFieldOnForm() {
+        SCSourceAForm source = new SCSourceAForm();
+        source.name = "Alpha";
+        source.setDoesNotExist("some value");
+        SCTargetA target = beanMapper.map(source, SCTargetA.class);
+        assertEquals("Alpha", target.name);
+        assertEquals("some value", target.doesExist);
+    }
+
+    @Test
+    public void strictMappingConventionWithPrivateFieldOnResult() {
+        SCSourceB source = new SCSourceB();
+        source.name = "Alpha";
+        source.doesExist = "some value";
+        SCTargetBResult target = beanMapper.map(source, SCTargetBResult.class);
+        assertEquals("Alpha", target.name);
+        assertEquals("some value", target.getDoesNotExist());
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/core/inspector/PropertyAccessorTest.java
+++ b/src/test/java/io/beanmapper/core/inspector/PropertyAccessorTest.java
@@ -68,7 +68,6 @@ public class PropertyAccessorTest {
         accessor.setValue(bean, "test");
         
         Assert.assertEquals("test setter", bean.myPropertyWithSetter);
-        Assert.assertEquals("test setter", accessor.getValue(bean));
     }
     
     @Test

--- a/src/test/java/io/beanmapper/testmodel/strictconvention/SCSourceAForm.java
+++ b/src/test/java/io/beanmapper/testmodel/strictconvention/SCSourceAForm.java
@@ -1,0 +1,17 @@
+package io.beanmapper.testmodel.strictconvention;
+
+public class SCSourceAForm {
+
+    public String name;
+
+    private String doesNotExist;
+
+    public void setDoesNotExist(String doesNotExist) {
+        this.doesNotExist = doesNotExist;
+    }
+
+    public String getDoesExist() {
+        return this.doesNotExist;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/strictconvention/SCSourceB.java
+++ b/src/test/java/io/beanmapper/testmodel/strictconvention/SCSourceB.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.strictconvention;
+
+public class SCSourceB {
+    public String name;
+    public String doesExist;
+}

--- a/src/test/java/io/beanmapper/testmodel/strictconvention/SCSourceCForm.java
+++ b/src/test/java/io/beanmapper/testmodel/strictconvention/SCSourceCForm.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.strictconvention;
+
+public class SCSourceCForm {
+    public String getCity() {
+        return "Leiden";
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/strictconvention/SCTargetA.java
+++ b/src/test/java/io/beanmapper/testmodel/strictconvention/SCTargetA.java
@@ -1,0 +1,8 @@
+package io.beanmapper.testmodel.strictconvention;
+
+public class SCTargetA {
+
+    public String name;
+    public String doesExist;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/strictconvention/SCTargetBResult.java
+++ b/src/test/java/io/beanmapper/testmodel/strictconvention/SCTargetBResult.java
@@ -1,0 +1,15 @@
+package io.beanmapper.testmodel.strictconvention;
+
+public class SCTargetBResult {
+
+    public String name;
+    private String doesNotExist;
+
+    public void setDoesExist(String doesExist) {
+        this.doesNotExist = doesExist;
+    }
+
+    public String getDoesNotExist() {
+        return doesNotExist;
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/strictconvention/SCTargetC.java
+++ b/src/test/java/io/beanmapper/testmodel/strictconvention/SCTargetC.java
@@ -1,0 +1,4 @@
+package io.beanmapper.testmodel.strictconvention;
+
+public class SCTargetC {
+}


### PR DESCRIPTION
Issue #78 BeanMapper contained an error in the FieldPropertyAccessor resulting in it always returning true when asked if it was readable. This resulted in more properties being marked as mapping candidates. This then resulted in the strict mapping convention validation failing, because matching properties on the other side were missing.