### PR TITLE
@BeanCollection usage should be CLEAR not REUSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **POSSIBLE BREAKING CHANGE!** Issue [#59](https://github.com/42BV/beanmapper/issues/59), **@BeanCollection usage should be CLEAR not REUSE**; the current collection usage is REUSE, which means the collection is used as is, keeping the target elements in the collection. In Hibernate, this will not trigger the deletion of orphans. The dominant option is to use CLEAR, which means that any target collection instance will be used, but its contents removed by calling clear(). By calling this method, a managed list (such as Hibernate does), will keep track of the removed elements (orphan deletion, if enabled).
 - Issue [#76](https://github.com/42BV/beanmapper/issues/78), **Support anonymous classes**; Instances that were created anonymously were not supported by the Unproxy. Now, it will check whether the class is anonymous. If this is the case, it will refer to its superclass and re-enter the unproxy process. 
 
 ## [1.0.1] - 2017-10-04

--- a/src/main/java/io/beanmapper/annotations/BeanCollection.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollection.java
@@ -13,16 +13,29 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BeanCollection {
 
+    /**
+     * Determines the class type of an element within the target collection. The class
+     * type will be used by BeanMapper to pass the target class type.
+     * @return the class type of a target element collection
+     */
     Class elementType();
 
+    /**
+     * If the target collection is null, BeanMapper will attempt to instantiate a new
+     * one. The result of this method will determine the class to instantiate.
+     * @return
+     */
     Class targetCollectionType() default void.class;
 
-    BeanCollectionUsage beanCollectionUsage() default BeanCollectionUsage.REUSE;
+    /**
+     * Determines how BeanMapper must deal with the target collection. The default option
+     * is to apply CLEAR, which means it will reuse the collection instance by calling clear()
+     * on it. If it does not exist, it will be created. Others options are REUSE (if the
+     * collection exists, it will not be changed upfront) or CONSTRUCT (the collection is
+     * newly constructed). Note that especially CONSTRUCT will not work with frameworks like
+     * Hibernate, since the managed collection will be removed in favor of a new, unmanaged
+     * one.
+     * @return the way the target collection must be dealt with
+     */
+    BeanCollectionUsage beanCollectionUsage() default BeanCollectionUsage.CLEAR;
 }
-
-// 3 zaken interessant om op te geven:
-// * het feit dat een deep inspection moet plaatsvinden OF type source / target expliciet meegeven
-//   * overwegen; alleen target meegeven, omdat source al impliciet bepaald is
-//   * overwegen; als lijst slim afgehandeld moet worden, dus altijd BeanMapper activeren?
-// * het feit dat een lijst nieuw geconstrueerd moet worden (new) + type, OF aanvullen van bestaande lijst
-// * of een reset moet plaatsvinden op een lijst (zoals bij aliassen wenselijk is)

--- a/src/main/java/io/beanmapper/annotations/BeanCollectionUsage.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollectionUsage.java
@@ -12,11 +12,11 @@ public enum BeanCollectionUsage {
      */
     CONSTRUCT,
     /**
-     * Reuse the target collection if it exists; construct if not. DEFAULT option
+     * Reuse the target collection if it exists; construct if not.
      */
     REUSE,
     /**
-     * Call clear on the target collection if it exists; construct if not
+     * Call clear on the target collection if it exists; construct if not. DEFAULT option
      */
     CLEAR
 

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -1,6 +1,7 @@
 package io.beanmapper;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -28,6 +29,10 @@ import io.beanmapper.testmodel.anonymous.BookForm;
 import io.beanmapper.testmodel.beanAlias.NestedSourceWithAlias;
 import io.beanmapper.testmodel.beanAlias.SourceWithAlias;
 import io.beanmapper.testmodel.beanAlias.TargetWithAlias;
+import io.beanmapper.testmodel.collections.CollSourceClear;
+import io.beanmapper.testmodel.collections.CollSourceReuse;
+import io.beanmapper.testmodel.collections.CollSourceConstruct;
+import io.beanmapper.testmodel.collections.CollTarget;
 import io.beanmapper.testmodel.collections.CollectionListSource;
 import io.beanmapper.testmodel.collections.CollectionListTarget;
 import io.beanmapper.testmodel.collections.CollectionListTargetClear;
@@ -1075,6 +1080,76 @@ public class BeanMapperTest {
         SCTargetBResult target = beanMapper.map(source, SCTargetBResult.class);
         assertEquals("Alpha", target.name);
         assertEquals("some value", target.getDoesNotExist());
+    }
+
+    @Test
+    public void beanCollectionClearEmptySource() {
+        CollSourceClear source = new CollSourceClear();
+        source.items = null;
+        CollTarget target = beanMapper.map(source, CollTarget.class);
+        assertNull(target.items);
+    }
+
+    @Test
+    public void beanCollectionReuseEmptySource() {
+        CollSourceReuse source = new CollSourceReuse();
+        source.items = null;
+        CollTarget target = beanMapper.map(source, CollTarget.class);
+        assertNull(target.items);
+    }
+
+    @Test
+    public void beanCollectionConstructEmptySource() {
+        CollSourceConstruct source = new CollSourceConstruct();
+        source.items = null;
+        CollTarget target = beanMapper.map(source, CollTarget.class);
+        assertNull(target.items);
+    }
+
+    @Test
+    public void beanCollectionClear() {
+        CollSourceClear source = new CollSourceClear();
+        source.items.add("A");
+        source.items.add("B");
+        source.items.add("C");
+        CollTarget target = new CollTarget();
+        target.items = new ArrayList<>();
+        List<String> expectedList = target.items;
+        target.items.add("D");
+        target = beanMapper.map(source, target);
+        assertEquals(expectedList, target.items);
+        assertEquals(3, target.items.size());
+    }
+
+    @Test
+    public void beanCollectionReuse() {
+        CollSourceReuse source = new CollSourceReuse();
+        source.items.add("A");
+        source.items.add("B");
+        source.items.add("C");
+        CollTarget target = new CollTarget();
+        target.items = new ArrayList<>();
+        List<String> expectedList = target.items;
+        target.items.add("D");
+        target = beanMapper.map(source, target);
+        assertEquals(4, target.items.size());
+        assertEquals(expectedList, target.items);
+        assertEquals("D", target.items.get(0));
+    }
+
+    @Test
+    public void beanCollectionConstruct() {
+        CollSourceConstruct source = new CollSourceConstruct();
+        source.items.add("A");
+        source.items.add("B");
+        source.items.add("C");
+        CollTarget target = new CollTarget();
+        target.items = new ArrayList<>();
+        List<String> unexpectedList = target.items;
+        target.items.add("D");
+        target = beanMapper.map(source, target);
+        assertEquals(3, target.items.size());
+        assertNotSame(unexpectedList, target.items);
     }
 
     @Test

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSourceClear.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSourceClear.java
@@ -1,0 +1,13 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class CollSourceClear {
+
+    @BeanCollection(elementType = CollTarget.class)
+    public List<String> items = new ArrayList<>();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSourceConstruct.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSourceConstruct.java
@@ -1,0 +1,14 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+import io.beanmapper.annotations.BeanCollectionUsage;
+
+public class CollSourceConstruct {
+
+    @BeanCollection(elementType = CollTarget.class, beanCollectionUsage = BeanCollectionUsage.CONSTRUCT)
+    public List<String> items = new ArrayList<>();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSourceReuse.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSourceReuse.java
@@ -1,0 +1,14 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+import io.beanmapper.annotations.BeanCollectionUsage;
+
+public class CollSourceReuse {
+
+    @BeanCollection(elementType = CollTarget.class, beanCollectionUsage = BeanCollectionUsage.REUSE)
+    public List<String> items = new ArrayList<>();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollTarget.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollTarget.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.List;
+
+public class CollTarget {
+
+    public List<String> items;
+
+}


### PR DESCRIPTION
Issue #59 The BeanCollection.beanCollectionUsage has its default changed from REUSE to CLEAR. The dominant option (bar none) is CLEAR, because this resets the target collection's available instance and triggers (for example) a managed list's action (such as deleting orphans for Hibernate). A quick scan of available projects proved this change will not pose a problem at all.

Documentation for BeanCollection has been extended.