### PR TITLE
The name field from an enum is not mapped to target field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Issue [#83](https://github.com/42BV/beanmapper/issues/83), **The name field from an enum is not mapped to target field**; in the resolution of issue [#78](https://github.com/42BV/beanmapper/issues/78) the definition of getter fields has been tightened, because previously all private fields were tagged as available as well. One project made use of this loophole by reading the name field of an enumeration class to a String field. With the new fix this is no longer possible, since the name field is private. This fix makes an exception for the name field of an enum class. It will be considered available for reading.
+
 ## [2.0.0] - 2017-10-12
 ### Fixed
 - **POSSIBLE BREAKING CHANGE!** Issue [#59](https://github.com/42BV/beanmapper/issues/59), **@BeanCollection usage should be CLEAR not REUSE**; the current collection usage is REUSE, which means the collection is used as is, keeping the target elements in the collection. In Hibernate, this will not trigger the deletion of orphans. The dominant option is to use CLEAR, which means that any target collection instance will be used, but its contents removed by calling clear(). By calling this method, a managed list (such as Hibernate does), will keep track of the removed elements (orphan deletion, if enabled).

--- a/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
@@ -55,9 +55,13 @@ public class FieldPropertyAccessor implements PropertyAccessor {
      */
     @Override
     public boolean isReadable() {
-        return Modifier.isPublic(field.getModifiers());
+        return nameOfEnum() || Modifier.isPublic(field.getModifiers());
     }
-    
+
+    private boolean nameOfEnum() {
+        return "name".equals(field.getName()) && field.getDeclaringClass().equals(Enum.class);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +22,6 @@ import io.beanmapper.core.converter.impl.LocalDateTimeToLocalDate;
 import io.beanmapper.core.converter.impl.LocalDateToLocalDateTime;
 import io.beanmapper.core.converter.impl.NestedSourceClassToNestedTargetClassConverter;
 import io.beanmapper.core.converter.impl.ObjectToStringConverter;
-import io.beanmapper.exceptions.BeanCollectionUnassignableTargetCollectionTypeException;
 import io.beanmapper.exceptions.BeanConversionException;
 import io.beanmapper.exceptions.BeanMappingException;
 import io.beanmapper.testmodel.anonymous.Book;
@@ -82,6 +80,8 @@ import io.beanmapper.testmodel.enums.ColorStringResult;
 import io.beanmapper.testmodel.enums.EnumSourceArraysAsList;
 import io.beanmapper.testmodel.enums.EnumTargetList;
 import io.beanmapper.testmodel.enums.RGB;
+import io.beanmapper.testmodel.enums.UserRole;
+import io.beanmapper.testmodel.enums.UserRoleResult;
 import io.beanmapper.testmodel.ignore.IgnoreSource;
 import io.beanmapper.testmodel.ignore.IgnoreTarget;
 import io.beanmapper.testmodel.initiallyunmatchedsource.SourceWithUnmatchedField;
@@ -1199,6 +1199,15 @@ public class BeanMapperTest {
         assertEquals(bookForm.name, book.getName());
         assertEquals(bookForm.street, book.getStreet());
         assertEquals(bookForm.city, book.getCity());
+    }
+
+    @Test
+    public void beanMapper_shouldMapFieldsFromSuperclass() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .setApplyStrictMappingConvention(false)
+                .build();
+        UserRoleResult result = beanMapper.map(UserRole.ADMIN, UserRoleResult.class);
+        assertEquals(UserRole.ADMIN.name(), result.name);
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/testmodel/enums/UserRole.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/UserRole.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.enums;
+
+public enum UserRole {
+    ADMIN
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/UserRoleResult.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/UserRoleResult.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.enums;
+
+public class UserRoleResult {
+    public String name;
+}


### PR DESCRIPTION
Issue #83 In the resolution of issue #78 the definition of getter fields has been tightened, because previously all private fields were tagged as available as well. One project made use of this loophole by reading the name field of an enumeration class to a String field. With the new fix this is no longer possible, since the name field is private.

This fix makes an exception for the name field of an enum class. It will be considered available for reading.