### PR TITLE
BeanMapper executes the list of AfterClearFlusher instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Fixed
 - Issue [#83](https://github.com/42BV/beanmapper/issues/83), **The name field from an enum is not mapped to target field**; in the resolution of issue [#78](https://github.com/42BV/beanmapper/issues/78) the definition of getter fields has been tightened, because previously all private fields were tagged as available as well. One project made use of this loophole by reading the name field of an enumeration class to a String field. With the new fix this is no longer possible, since the name field is private. This fix makes an exception for the name field of an enum class. It will be considered available for reading.
+### Added
+- Issue [#84](https://github.com/42BV/beanmapper/issues/84), **BeanMapper executes the list of AfterClearFlusher instances**; when a clear method on a collection is called, BeanMapper makes sure to run down the list of registered AfterClearFlusher instances. On every instance, the flush method will be called. By default **no** AfterClearFlusher instances are added. BeanMapper has no notion of ORMs; this is left to [beanmapper-spring](https://github.com/42BV/beanmapper-spring) and [beanmapper-spring-boot-starter](https://github.com/42BV/beanmapper-spring-boot-starter). Note that the flusher chain is only called when it has been set to do so in the BeanCollection annotation or the override configuration (flushAfterClear).
 
 ## [2.0.0] - 2017-10-12
 ### Fixed

--- a/src/main/java/io/beanmapper/annotations/BeanCollection.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollection.java
@@ -40,4 +40,18 @@ public @interface BeanCollection {
      */
     Class preferredCollectionClass() default void.class;
 
+    /**
+     * When usage is CLEAR and the target collection is being managed by, eg, Hibernate's
+     * OneToMany in combination with orphanRemoval=true, clearing the collection will trigger
+     * delete statements. The problem is that these statements are executed AFTER the insert
+     * statements. If a record is constrained by unicity, this might lead to a constraint
+     * violation. One way to solve this is by asking BeanMapper to flush after the call to
+     * clear. This will force Hibernate to perform the delete before the insert statements.
+     * Note that the flush also persists any merged entity. You are advised to use this
+     * functionality in combination with Lazy to make sure BeanMapper operates within the
+     * transaction scope. If you do, the flush action can be rolled back, resulting in the
+     * original state being preserved.
+     */
+    boolean flushAfterClear() default false;
+
 }

--- a/src/main/java/io/beanmapper/config/AfterClearFlusher.java
+++ b/src/main/java/io/beanmapper/config/AfterClearFlusher.java
@@ -1,0 +1,19 @@
+package io.beanmapper.config;
+
+/**
+ * After BeanMapper calls the clear() method on a collection, it will check for the
+ * presence of AfterClearFlusher instance. All instances found will be executed. The
+ * use case triggering this functionality is the fact that Hibernate's @OneToMany first
+ * executes insert SQL-statements, before the delete SQL statements. With constraints,
+ * this is an issue. By forcing the flush after a clear, Hibernate is forced to first
+ * execute its delete SQL-statements, before the inserts.
+ */
+public interface AfterClearFlusher {
+
+    /**
+     * Calls the flush method. Typically, this is used to force an ORM implementation
+     * to flush its cache.
+     */
+    void flush();
+
+}

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -98,6 +98,11 @@ public class BeanMapperBuilder {
         return this;
     }
 
+    public BeanMapperBuilder addAfterClearFlusher(AfterClearFlusher afterClearFlusher) {
+        this.configuration.addAfterClearFlusher(afterClearFlusher);
+        return this;
+    }
+
     public BeanMapperBuilder setBeanInitializer(BeanInitializer beanInitializer) {
         this.configuration.setBeanInitializer(beanInitializer);
         return this;
@@ -167,6 +172,11 @@ public class BeanMapperBuilder {
 
     public BeanMapperBuilder setPreferredCollectionClass(Class<?> preferredCollectionClass) {
         this.configuration.setPreferredCollectionClass(preferredCollectionClass);
+        return this;
+    }
+
+    public BeanMapperBuilder setFlushAfterClear(Boolean flushAfterClear) {
+        this.configuration.setFlushAfterClear(flushAfterClear);
         return this;
     }
 

--- a/src/main/java/io/beanmapper/config/CollectionFlusher.java
+++ b/src/main/java/io/beanmapper/config/CollectionFlusher.java
@@ -1,0 +1,27 @@
+package io.beanmapper.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollectionFlusher {
+
+    private List<AfterClearFlusher> afterClearFlushers = new ArrayList<AfterClearFlusher>();
+
+    public List<AfterClearFlusher> getAfterClearFlushers() {
+        return this.afterClearFlushers;
+    }
+
+    public void addAfterClearFlusher(AfterClearFlusher afterClearFlusher) {
+        this.afterClearFlushers.add(afterClearFlusher);
+    }
+
+    public void flush(Boolean flushAfterClear) {
+        if (!flushAfterClear) {
+            return;
+        }
+        for (AfterClearFlusher afterClearFlusher : afterClearFlushers) {
+            afterClearFlusher.flush();
+        }
+    }
+
+}

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -158,6 +158,21 @@ public interface Configuration {
     Class<?> getPreferredCollectionClass();
 
     /**
+     * Returns the collection clearer, which takes care of calling the clear method
+     * on a collection. If required, it will also call the list of flushers registered
+     * to it.
+     * @return the collection clearer
+     */
+    CollectionFlusher getCollectionFlusher();
+
+    /**
+     * Determines if the flush-chain must be called after a clear() operation on a
+     * collection has taken place.
+     * @return true if the flush-chain must be called after a clear
+     */
+    Boolean isFlushAfterClear();
+
+    /**
      * Add a converter class (must inherit from abstract BeanConverter class) to the beanMapper.
      * On mapping, the beanMapper will check for a suitable converter and use its from and
      * to methods to convert the value of the fields to the correct new data type.
@@ -214,6 +229,17 @@ public interface Configuration {
      * @param packagePrefix the String which sets the package prefix for all mappable classes
      */
     void addPackagePrefix(String packagePrefix);
+
+    /**
+     * After BeanMapper calls the clear() method on a collection, it will check for the
+     * presence of AfterClearFlusher instances. All instances found will be executed. The
+     * use case triggering this functionality is the fact that Hibernate's @OneToMany first
+     * executes insert SQL-statements, before the delete SQL statements. With constraints,
+     * this is an issue. By forcing the flush after a clear, Hibernate is forced to first
+     * execute its delete SQL-statements, before the inserts.
+     * @param afterClearFlusher the flusher to be added to the call stack after a clear call
+     */
+    void addAfterClearFlusher(AfterClearFlusher afterClearFlusher);
 
     void setBeanInitializer(BeanInitializer beanInitializer);
 
@@ -313,5 +339,11 @@ public interface Configuration {
      * @param preferredCollectionClass the collection class to prefer for instantiation
      */
     void setPreferredCollectionClass(Class<?> preferredCollectionClass);
+
+    /**
+     * Determines whether the flush-chain must be called after a clear has taken place.
+     * @param flushAfterClear true if the flush-chain must be called
+     */
+    void setFlushAfterClear(Boolean flushAfterClear);
 
 }

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -65,6 +65,8 @@ public class CoreConfiguration implements Configuration {
 
     private List<CollectionHandler> collectionHandlers = new ArrayList<CollectionHandler>();
 
+    private CollectionFlusher collectionFlusher = new CollectionFlusher();
+
     @Override
     public List<String> getDownsizeTarget() { return null; }
 
@@ -197,6 +199,16 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
+    public CollectionFlusher getCollectionFlusher() {
+        return this.collectionFlusher;
+    }
+
+    @Override
+    public Boolean isFlushAfterClear() {
+        return false;
+    }
+
+    @Override
     public void addConverter(BeanConverter converter) {
         this.beanConverters.add(converter);
     }
@@ -231,6 +243,11 @@ public class CoreConfiguration implements Configuration {
     @Override
     public void addPackagePrefix(String packagePrefix) {
         this.packagePrefixes.add(packagePrefix);
+    }
+
+    @Override
+    public void addAfterClearFlusher(AfterClearFlusher afterClearFlusher) {
+        this.collectionFlusher.addAfterClearFlusher(afterClearFlusher);
     }
 
     @Override
@@ -323,6 +340,12 @@ public class CoreConfiguration implements Configuration {
     public void setPreferredCollectionClass(Class<?> preferredCollectionClass) {
         throw new BeanConfigurationOperationNotAllowedException(
                 "Illegal to set preferred collection class on the core configuration");
+    }
+
+    @Override
+    public void setFlushAfterClear(Boolean flushAfterClear) {
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to set flush after clear on the core configuration");
     }
 
 }

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -48,6 +48,8 @@ public class OverrideConfiguration implements Configuration {
 
     private Class<?> preferredCollectionClass = null;
 
+    private Boolean flushAfterClear = null;
+
     public OverrideConfiguration(Configuration configuration) {
         if (configuration == null) {
             throw new ParentConfigurationPossiblyNullException("Developer error: the parent configuration may not be null");
@@ -195,6 +197,18 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
+    public CollectionFlusher getCollectionFlusher() {
+        return parentConfiguration.getCollectionFlusher();
+    }
+
+    @Override
+    public Boolean isFlushAfterClear() {
+        return this.flushAfterClear == null ?
+                parentConfiguration.isFlushAfterClear() :
+                this.flushAfterClear;
+    }
+
+    @Override
     public void addConverter(BeanConverter converter) {
         beanConverters.add(converter);
     }
@@ -226,6 +240,11 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void addPackagePrefix(String packagePrefix) {
+        // not supported for override options
+    }
+
+    @Override
+    public void addAfterClearFlusher(AfterClearFlusher afterClearFlusher) {
         // not supported for override options
     }
 
@@ -310,6 +329,11 @@ public class OverrideConfiguration implements Configuration {
     @Override
     public void setPreferredCollectionClass(Class<?> preferredCollectionClass) {
         this.preferredCollectionClass = preferredCollectionClass;
+    }
+
+    @Override
+    public void setFlushAfterClear(Boolean flushAfterClear) {
+        this.flushAfterClear = flushAfterClear;
     }
 
 }

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -158,6 +158,7 @@ public class BeanMatchStore {
         collectionInstructions.setCollectionMapsTo(beanCollection.elementType());
         collectionInstructions.setBeanCollectionUsage(beanCollection.beanCollectionUsage());
         collectionInstructions.setPreferredInstantiatedClass(beanCollection.preferredCollectionClass());
+        collectionInstructions.setFlushAfterClear(beanCollection.flushAfterClear());
         beanField.setCollectionInstructions(collectionInstructions);
     }
 

--- a/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
@@ -2,6 +2,7 @@ package io.beanmapper.core.collections;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.annotations.BeanCollectionUsage;
+import io.beanmapper.config.CollectionFlusher;
 import io.beanmapper.core.constructor.DefaultBeanInitializer;
 import io.beanmapper.exceptions.BeanCollectionUnassignableTargetCollectionTypeException;
 import io.beanmapper.utils.Classes;
@@ -44,14 +45,17 @@ public abstract class AbstractCollectionHandler<C> implements CollectionHandler<
     public C getTargetCollection(
             BeanCollectionUsage collectionUsage,
             Class<C> preferredCollectionClass,
-            C targetCollection) {
+            C targetCollection,
+            CollectionFlusher collectionFlusher,
+            Boolean flushAfterClear) {
 
         C useTargetCollection = collectionUsage.mustConstruct(targetCollection) ?
                 createCollection(preferredCollectionClass) :
                 targetCollection;
 
-        if (collectionUsage.mustClear()) {
+        if (collectionUsage.mustClear() && size(useTargetCollection) > 0) {
             clear(useTargetCollection);
+            collectionFlusher.flush(flushAfterClear);
         }
 
         return useTargetCollection;

--- a/src/main/java/io/beanmapper/core/collections/CollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/CollectionHandler.java
@@ -1,7 +1,11 @@
 package io.beanmapper.core.collections;
 
+import java.util.List;
+
 import io.beanmapper.BeanMapper;
 import io.beanmapper.annotations.BeanCollectionUsage;
+import io.beanmapper.config.AfterClearFlusher;
+import io.beanmapper.config.CollectionFlusher;
 
 /**
  * Deals with the basic collection manipulations required by BeanMapper
@@ -36,7 +40,9 @@ public interface CollectionHandler<C> {
     public C getTargetCollection(
             BeanCollectionUsage collectionUsage,
             Class<C> targetCollectionType,
-            C targetCollection);
+            C targetCollection,
+            CollectionFlusher collectionFlusher,
+            Boolean flushAfterClear);
 
     /**
      * The type of the collection class. This will be used to determine if the source
@@ -52,5 +58,7 @@ public interface CollectionHandler<C> {
      * @return true if the class can be upcast to the type
      */
     public boolean isMatch(Class<?> clazz);
+
+    public int size(C targetCollection);
 
 }

--- a/src/main/java/io/beanmapper/core/collections/ListCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/ListCollectionHandler.java
@@ -16,6 +16,11 @@ public class ListCollectionHandler extends AbstractCollectionHandler<List> {
     }
 
     @Override
+    public int size(List targetCollection) {
+        return targetCollection.size();
+    }
+
+    @Override
     protected void clear(List target) {
         target.clear();
     }

--- a/src/main/java/io/beanmapper/core/collections/MapCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/MapCollectionHandler.java
@@ -18,6 +18,11 @@ public class MapCollectionHandler extends AbstractCollectionHandler<Map> {
     }
 
     @Override
+    public int size(Map targetCollection) {
+        return targetCollection.size();
+    }
+
+    @Override
     protected void clear(Map target) {
         target.clear();
     }

--- a/src/main/java/io/beanmapper/core/collections/SetCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/SetCollectionHandler.java
@@ -16,6 +16,11 @@ public class SetCollectionHandler extends AbstractCollectionHandler<Set> {
     }
 
     @Override
+    public int size(Set targetCollection) {
+        return targetCollection.size();
+    }
+
+    @Override
     protected void clear(Set target) {
         target.clear();
     }

--- a/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
@@ -10,6 +10,8 @@ public class BeanCollectionInstructions {
 
     private Class<?> preferredInstantiatedClass;
 
+    private Boolean flushAfterClear;
+
     public Class getCollectionMapsTo() {
         return collectionMapsTo;
     }
@@ -37,4 +39,11 @@ public class BeanCollectionInstructions {
                 preferredInstantiatedClass;
     }
 
+    public Boolean getFlushAfterClear() {
+        return flushAfterClear;
+    }
+
+    public void setFlushAfterClear(Boolean flushAfterClear) {
+        this.flushAfterClear = flushAfterClear;
+    }
 }

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -30,6 +30,7 @@ public class CollectionConverter<T> implements BeanConverter {
                 .setCollectionClass(collectionHandler.getType())
                 .setCollectionUsage(beanFieldMatch.getCollectionInstructions().getBeanCollectionUsage())
                 .setPreferredCollectionClass(beanFieldMatch.getCollectionInstructions().getPreferredInstantiatedClass())
+                .setFlushAfterClear(beanFieldMatch.getCollectionInstructions().getFlushAfterClear())
                 .setTargetClass(beanFieldMatch.getCollectionInstructions().getCollectionMapsTo())
                 .setTarget(beanFieldMatch.getTargetObject())
                 .build()

--- a/src/main/java/io/beanmapper/strategy/MapCollectionStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapCollectionStrategy.java
@@ -19,7 +19,9 @@ public class MapCollectionStrategy extends AbstractMapStrategy {
         Object targetItems = collectionHandler.getTargetCollection(
             this.getConfiguration().getCollectionUsage(),
             this.getConfiguration().getPreferredCollectionClass(),
-            this.getConfiguration().getTarget()
+            this.getConfiguration().getTarget(),
+            this.getConfiguration().getCollectionFlusher(),
+            this.getConfiguration().isFlushAfterClear()
         );
 
         targetItems = collectionHandler.copy(

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSourceClearFlush.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSourceClearFlush.java
@@ -1,0 +1,13 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class CollSourceClearFlush {
+
+    @BeanCollection(elementType = CollTarget.class, flushAfterClear = true)
+    public List<String> items = new ArrayList<>();
+
+}


### PR DESCRIPTION
Issue #84 states that usage of Hibernate's @OneToMany leads to the known problem of Hibernate first executing its insert, then its delete SQL-statements. When the table uses (as it well should) unique constraints, this leads to a violation. The dirty quickfix is to disable the constraints. The long-term fix is for BeanMapper to force the ORM to flush, effectively reversing the order of delete and insert SQL-statements.

When a clear method on a collection is called, BeanMapper makes sure to run down the list of registered AfterClearFlusher instances. On every instance, the flush method will be called. By default AfterClearFlusher instances are added. BeanMapper has no notion of ORMs; this is left to [beanmapper-spring](https://github.com/42BV/beanmapper-spring) and [beanmapper-spring-boot-starter](https://github.com/42BV/beanmapper-spring-boot-starter).