### PR TITLE
Unmatched BeanProperty did not throw an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Issue [#60](https://github.com/42BV/beanmapper/issues/60), **Unmatched BeanProperty did not throw an exception**; properties annotated with BeanProperty must match. If they do not, an exception must be thrown. Due to a bug, this did not always occur (only with BeanProperty on the target side). The current mechanism keep tabs on matched properties and does a final verification. If unmatched properties remain that should have been matched, an exception is thrown.
 
 ## [2.1.0] - 2017-10-25
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper</name>
     <description>Easy-to-use bean mapper for conversion from form to object to view</description>

--- a/src/main/java/io/beanmapper/core/BeanField.java
+++ b/src/main/java/io/beanmapper/core/BeanField.java
@@ -22,6 +22,18 @@ public class BeanField {
 
     private BeanCollectionInstructions collectionInstructions;
 
+    private boolean mustMatch = false;
+
+    private boolean matched = false;
+
+    public boolean isMustMatch() {
+        return mustMatch;
+    }
+
+    public void setMustMatch(boolean mustMatch) {
+        this.mustMatch = mustMatch;
+    }
+
     public BeanField(String name, PropertyAccessor accessor) {
         this.name = name;
         this.accessor = accessor;
@@ -157,6 +169,14 @@ public class BeanField {
             beanFields.push(new BeanField(node, property));
             currentBaseClass = property.getType();
         }
+    }
+
+    public void setMatched() {
+        matched = true;
+    }
+
+    public boolean isUnmatched() {
+        return mustMatch && !matched;
     }
 
 }

--- a/src/main/java/io/beanmapper/core/BeanMatch.java
+++ b/src/main/java/io/beanmapper/core/BeanMatch.java
@@ -5,6 +5,10 @@ import java.util.List;
 import java.util.Map;
 
 import io.beanmapper.config.BeanPair;
+import io.beanmapper.exceptions.BeanNoSuchPropertyException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BeanMatch {
 
@@ -15,6 +19,8 @@ public class BeanMatch {
     private final Map<String, BeanField> targetNode;
 
     private final Map<String, BeanField> aliases;
+
+    private boolean verified = false;
 
     public BeanMatch(BeanPair beanPair, Map<String, BeanField> sourceNode, Map<String, BeanField> targetNode, Map<String, BeanField> aliases) {
         this.beanPair = beanPair;
@@ -87,6 +93,24 @@ public class BeanMatch {
             }
         }
         return missingMatches;
+    }
+
+    public void checkForMandatoryUnmatchedNodes() {
+        if (verified) {
+            return;
+        }
+        verified = true;
+        checkForMandatoryUnmatchedNodes("source", beanPair.getSourceClass(), sourceNode);
+        checkForMandatoryUnmatchedNodes("target", beanPair.getTargetClass(), targetNode);
+    }
+
+    private void checkForMandatoryUnmatchedNodes(String side, Class<?> containingClass, Map<String, BeanField> nodes) {
+        for (String key : nodes.keySet()) {
+            BeanField currentField = nodes.get(key);
+            if (currentField.isUnmatched()) {
+                throw new BeanNoSuchPropertyException(side + " " + containingClass.getCanonicalName() + " has no match for property " + key);
+            }
+        }
     }
 
 }

--- a/src/main/java/io/beanmapper/core/BeanPropertyWrapper.java
+++ b/src/main/java/io/beanmapper/core/BeanPropertyWrapper.java
@@ -1,0 +1,26 @@
+package io.beanmapper.core;
+
+public class BeanPropertyWrapper {
+    private String name;
+    private boolean mustMatch = false;
+
+    public BeanPropertyWrapper(String name) {
+        this.name = name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isMustMatch() {
+        return mustMatch;
+    }
+
+    public void setMustMatch() {
+        this.mustMatch = true;
+    }
+}

--- a/src/main/java/io/beanmapper/core/MatchedBeanPairField.java
+++ b/src/main/java/io/beanmapper/core/MatchedBeanPairField.java
@@ -9,6 +9,15 @@ public class MatchedBeanPairField {
     public MatchedBeanPairField(BeanField sourceBeanField, BeanField targetBeanField) {
         this.sourceBeanField = sourceBeanField;
         this.targetBeanField = targetBeanField;
+        setMatchedBeanField(sourceBeanField);
+        setMatchedBeanField(targetBeanField);
+    }
+
+    private void setMatchedBeanField(BeanField beanField) {
+        if (beanField == null) {
+            return;
+        }
+        beanField.setMatched();
     }
 
     public BeanField getSourceBeanField() {

--- a/src/main/java/io/beanmapper/exceptions/BeanNoSuchPropertyException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanNoSuchPropertyException.java
@@ -3,16 +3,19 @@
  */
 package io.beanmapper.exceptions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Exception thrown when a property could not be found.
- *
- * @author Jeroen van Schagen
- * @since Jun 24, 2015
  */
 public class BeanNoSuchPropertyException extends IllegalArgumentException {
-    
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
     public BeanNoSuchPropertyException(String message) {
         super(message);
+        logger.error(message);
     }
     
 }

--- a/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
@@ -164,6 +164,7 @@ public abstract class AbstractMapStrategy implements MapStrategy {
                     fieldName,
                     beanMatch));
         }
+        beanMatch.checkForMandatoryUnmatchedNodes();
         return target;
     }
 

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,11 +27,16 @@ import io.beanmapper.core.converter.impl.NestedSourceClassToNestedTargetClassCon
 import io.beanmapper.core.converter.impl.ObjectToStringConverter;
 import io.beanmapper.exceptions.BeanConversionException;
 import io.beanmapper.exceptions.BeanMappingException;
+import io.beanmapper.exceptions.BeanNoSuchPropertyException;
 import io.beanmapper.testmodel.anonymous.Book;
 import io.beanmapper.testmodel.anonymous.BookForm;
 import io.beanmapper.testmodel.beanAlias.NestedSourceWithAlias;
 import io.beanmapper.testmodel.beanAlias.SourceWithAlias;
 import io.beanmapper.testmodel.beanAlias.TargetWithAlias;
+import io.beanmapper.testmodel.beanproperty.SourceBeanProperty;
+import io.beanmapper.testmodel.beanproperty.SourceNestedBeanProperty;
+import io.beanmapper.testmodel.beanproperty.TargetBeanProperty;
+import io.beanmapper.testmodel.beanproperty.TargetNestedBeanProperty;
 import io.beanmapper.testmodel.collections.CollSourceClear;
 import io.beanmapper.testmodel.collections.CollSourceClearFlush;
 import io.beanmapper.testmodel.collections.CollSourceConstruct;
@@ -1259,6 +1265,35 @@ public class BeanMapperTest {
                 .build();
         UserRoleResult result = beanMapper.map(UserRole.ADMIN, UserRoleResult.class);
         assertEquals(UserRole.ADMIN.name(), result.name);
+    }
+
+    @Test
+    public void unmodifiableRandomAccessList() {
+        List<Long> numbers = Collections.unmodifiableList(new ArrayList<Long>() {{
+            add(42L);
+            add(57L);
+            add(33L);
+        }});
+        List<String> numbersAsText = beanMapper.map(numbers, String.class);
+        assertEquals(3, numbersAsText.size());
+        assertEquals("42", numbersAsText.get(0));
+    }
+
+    @Test(expected = BeanNoSuchPropertyException.class)
+    public void beanPropertyMismatch() {
+        SourceBeanProperty source = new SourceBeanProperty() {{
+            age = 42;
+        }};
+        beanMapper.map(source, TargetBeanProperty.class);
+    }
+
+    @Test(expected = BeanNoSuchPropertyException.class)
+    public void beanPropertyNestedMismatch() {
+        SourceNestedBeanProperty source = new SourceNestedBeanProperty() {{
+            value1 = "42";
+            value2 = "33";
+        }};
+        beanMapper.map(source, TargetNestedBeanProperty.class);
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/testmodel/beanproperty/SourceBeanProperty.java
+++ b/src/test/java/io/beanmapper/testmodel/beanproperty/SourceBeanProperty.java
@@ -1,0 +1,10 @@
+package io.beanmapper.testmodel.beanproperty;
+
+import io.beanmapper.annotations.BeanProperty;
+
+public class SourceBeanProperty {
+
+    @BeanProperty(name = "age2")
+    public Integer age;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/beanproperty/SourceNestedBeanProperty.java
+++ b/src/test/java/io/beanmapper/testmodel/beanproperty/SourceNestedBeanProperty.java
@@ -1,0 +1,13 @@
+package io.beanmapper.testmodel.beanproperty;
+
+import io.beanmapper.annotations.BeanProperty;
+
+public class SourceNestedBeanProperty {
+
+    @BeanProperty(name = "alpha.beta.gamma")
+    public String value1;
+
+    @BeanProperty(name = "alpha.beta.delta")
+    public String value2;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/beanproperty/TargetBeanProperty.java
+++ b/src/test/java/io/beanmapper/testmodel/beanproperty/TargetBeanProperty.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.beanproperty;
+
+public class TargetBeanProperty {
+
+    public Integer age;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/beanproperty/TargetNestedBeanProperty.java
+++ b/src/test/java/io/beanmapper/testmodel/beanproperty/TargetNestedBeanProperty.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.beanproperty;
+
+public class TargetNestedBeanProperty {
+
+    public TargetNestedBeanPropertyAlpha alpha;
+}

--- a/src/test/java/io/beanmapper/testmodel/beanproperty/TargetNestedBeanPropertyAlpha.java
+++ b/src/test/java/io/beanmapper/testmodel/beanproperty/TargetNestedBeanPropertyAlpha.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.beanproperty;
+
+public class TargetNestedBeanPropertyAlpha {
+
+    public TargetNestedBeanPropertyBeta beta;
+}

--- a/src/test/java/io/beanmapper/testmodel/beanproperty/TargetNestedBeanPropertyBeta.java
+++ b/src/test/java/io/beanmapper/testmodel/beanproperty/TargetNestedBeanPropertyBeta.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.beanproperty;
+
+public class TargetNestedBeanPropertyBeta {
+
+    public Long gamma;
+}


### PR DESCRIPTION
Issue #60 properties annotated with BeanProperty must match. If they do not, an exception must be thrown. Due to a bug, this did not always occur (only with BeanProperty on the target side). The current mechanism keep tabs on matched properties and does a final verification. If unmatched properties remain that should have been matched, an exception is thrown.

Opened new snapshot version

Added test for #64 to prove it now works