### PR TITLE
Collections in super classes & Collections.EmptySet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Issue [#99](https://github.com/42BV/beanmapper/issues/99), **Collections in superclasses did not get their generic types read**; one of the attributes of getDeclaredField(field) is that it only works on the active class. The fix means that the superclasses will be checked for presence of the field. When found, it will call getDeclaredField on that class to get its generic type. Also, collection mapping instructions are not used when no collection element type can be determined; that is the one crucial element required for mapping collections. 
+- Issue [#100](https://github.com/42BV/beanmapper/issues/100), **Collections.EmptySet can not have add() called on**; BeanCollectionUsage will check the canonical classname of the collection. If it starts with "java.util.Collections.", it will be tagged as reconstructable.
 
 ## [2.3.0] - 2017-11-02
 ### Added
 - Issue [#92](https://github.com/42BV/beanmapper/issues/92), **BeanCollection no longer required for mapping collections**; BeanMapper is now capable of determining the collection element type of the target collection by examining the generic type. It will use this type as input for the mapping process. BeanCollection.elementType is no longer a required value. BeanMapper will merge collection information from target and source, giving preference to target information. 
-### Added
 - Issue [#97](https://github.com/42BV/beanmapper/issues/97), **StringToEnumConverter replaced with AnyToEnumConverter**; this makes it possible to convert enums to enums as well. Functionality is required because lists are no longer copied by reference by default. 
 
 ## [2.2.0] - 2017-11-01

--- a/src/main/java/io/beanmapper/annotations/BeanCollectionUsage.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollectionUsage.java
@@ -33,6 +33,10 @@ public enum BeanCollectionUsage {
     }
 
     public boolean mustConstruct(Object targetCollection) {
+        if (    targetCollection != null &&
+                targetCollection.getClass().getCanonicalName().startsWith("java.util.Collections.")) {
+            return true;
+        }
         return this.construct || targetCollection == null;
     }
 

--- a/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
@@ -5,7 +5,7 @@ import io.beanmapper.core.BeanField;
 
 public class BeanCollectionInstructions {
 
-    private Class<?> collectionElementType;
+    private CollectionElementType collectionElementType;
 
     private BeanCollectionUsage beanCollectionUsage;
 
@@ -13,11 +13,11 @@ public class BeanCollectionInstructions {
 
     private Boolean flushAfterClear;
 
-    public Class<?> getCollectionElementType() {
+    public CollectionElementType getCollectionElementType() {
         return collectionElementType;
     }
 
-    public void setCollectionElementType(Class<?> collectionElementType) {
+    public void setCollectionElementType(CollectionElementType collectionElementType) {
         this.collectionElementType = collectionElementType;
     }
 
@@ -80,15 +80,38 @@ public class BeanCollectionInstructions {
                 target.getBeanCollectionUsage(),
                 source == null ? null : source.getBeanCollectionUsage(),
                 BeanCollectionUsage.CLEAR));
-        merged.setCollectionElementType(chooseValue(
-                target.getCollectionElementType(),
-                source == null ? null : source.getCollectionElementType(),
-                null));
         merged.setPreferredCollectionClass(chooseValue(
                 target.getPreferredCollectionClass(),
                 source == null ? null : source.getPreferredCollectionClass(),
                 null));
+
+        merged.setCollectionElementType(determineCollectionElementType(target, source));
+
+        if (merged.getCollectionElementType() == null) {
+            return null;
+        }
+
         return merged;
+    }
+
+    private static CollectionElementType determineCollectionElementType(
+            BeanCollectionInstructions target, BeanCollectionInstructions source) {
+
+        CollectionElementType sourceCollectionElementType = source == null ? null : source.getCollectionElementType();
+        CollectionElementType targetCollectionElementType = target.getCollectionElementType();
+
+        if (
+                sourceCollectionElementType != null &&
+                targetCollectionElementType != null &&
+                !sourceCollectionElementType.isDerived() &&
+                targetCollectionElementType.isDerived()) {
+            targetCollectionElementType = null;
+        }
+
+        return chooseValue(
+                targetCollectionElementType,
+                sourceCollectionElementType,
+                null);
     }
 
     private static <C> C chooseValue(C target, C source, C defaultValue) {

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -31,7 +31,7 @@ public class CollectionConverter<T> implements BeanConverter {
                 .setCollectionUsage(beanFieldMatch.getCollectionInstructions().getBeanCollectionUsage())
                 .setPreferredCollectionClass(beanFieldMatch.getCollectionInstructions().getPreferredCollectionClass())
                 .setFlushAfterClear(beanFieldMatch.getCollectionInstructions().getFlushAfterClear())
-                .setTargetClass(beanFieldMatch.getCollectionInstructions().getCollectionElementType())
+                .setTargetClass(beanFieldMatch.getCollectionInstructions().getCollectionElementType().getType())
                 .setTarget(beanFieldMatch.getTargetObject())
                 .build()
                 .map(sourceCollection);

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionElementType.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionElementType.java
@@ -1,0 +1,30 @@
+package io.beanmapper.core.converter.collections;
+
+public class CollectionElementType {
+
+    private final Class<?> collectionElementType;
+
+    private final boolean derived;
+
+    private CollectionElementType(Class<?> collectionElementType, boolean derived) {
+        this.collectionElementType = collectionElementType;
+        this.derived = derived;
+    }
+
+    public static CollectionElementType set(Class<?> collectionElementType) {
+        return new CollectionElementType(collectionElementType, false);
+    }
+
+    public static CollectionElementType derived(Class<?> collectionElementType) {
+        return new CollectionElementType(collectionElementType, true);
+    }
+
+    public boolean isDerived() {
+        return derived;
+    }
+
+    public Class<?> getType() {
+        return collectionElementType;
+    }
+
+}

--- a/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
+++ b/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
@@ -96,7 +96,7 @@ public class ClassGenerator {
     private void handleBeanCollection(
             CtField field, BeanCollectionInstructions collectionInstructions,
             Node displayNodes, StrictMappingProperties strictMappingProperties) throws Exception {
-        GeneratedClass elementClass = createClass(collectionInstructions.getCollectionElementType(), displayNodes, strictMappingProperties);
+        GeneratedClass elementClass = createClass(collectionInstructions.getCollectionElementType().getType(), displayNodes, strictMappingProperties);
 
         ConstPool constPool = field.getDeclaringClass().getClassFile().getConstPool();
         AnnotationsAttribute attr= new AnnotationsAttribute(constPool, AnnotationsAttribute.visibleTag);

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -43,10 +44,15 @@ import io.beanmapper.testmodel.collections.CollSourceConstruct;
 import io.beanmapper.testmodel.collections.CollSourceListIncompleteAnnotation;
 import io.beanmapper.testmodel.collections.CollSourceListNotAnnotated;
 import io.beanmapper.testmodel.collections.CollSourceMapNotAnnotated;
+import io.beanmapper.testmodel.collections.CollSourceNoGenerics;
 import io.beanmapper.testmodel.collections.CollSourceReuse;
+import io.beanmapper.testmodel.collections.CollSubTargetList;
 import io.beanmapper.testmodel.collections.CollTarget;
+import io.beanmapper.testmodel.collections.CollTargetEmptyList;
 import io.beanmapper.testmodel.collections.CollTargetListNotAnnotated;
+import io.beanmapper.testmodel.collections.CollTargetListNotAnnotatedUseSetter;
 import io.beanmapper.testmodel.collections.CollTargetMapNotAnnotated;
+import io.beanmapper.testmodel.collections.CollTargetNoGenerics;
 import io.beanmapper.testmodel.collections.CollectionListSource;
 import io.beanmapper.testmodel.collections.CollectionListTarget;
 import io.beanmapper.testmodel.collections.CollectionListTargetClear;
@@ -440,6 +446,19 @@ public class BeanMapperTest {
     }
 
     @Test
+    public void mapNonAnnotatedListUseSetter() {
+        CollSourceListNotAnnotated source = new CollSourceListNotAnnotated() {{
+            list.add(42L);
+            list.add(33L);
+        }};
+        CollTargetListNotAnnotatedUseSetter target = beanMapper.map(source, CollTargetListNotAnnotatedUseSetter.class);
+        assertNotSame("Source and Target list may not be the same, must be copied", source.list, target.getList());
+        assertEquals(2, target.getList().size());
+        assertEquals("42", target.getList().get(0));
+        assertEquals("33", target.getList().get(1));
+    }
+
+    @Test
     public void mapIncompletelyAnnotatedList() {
         CollSourceListIncompleteAnnotation source = new CollSourceListIncompleteAnnotation() {{
             list.add(42L);
@@ -463,6 +482,45 @@ public class BeanMapperTest {
         assertEquals(2, target.map.size());
         assertEquals((Long)42L, target.map.get("a"));
         assertEquals((Long)33L, target.map.get("b"));
+    }
+
+    @Test
+    public void mapNonAnnotatedListInSuperClass() {
+        CollSourceListNotAnnotated source = new CollSourceListNotAnnotated() {{
+            list.add(42L);
+            list.add(33L);
+        }};
+        CollSubTargetList target = beanMapper.map(source, CollSubTargetList.class);
+        assertNotSame("Source and Target list may not be the same, must be copied", source.list, target.list);
+        assertEquals(2, target.list.size());
+        assertEquals("42", target.list.get(0));
+        assertEquals("33", target.list.get(1));
+    }
+
+    @Test
+    public void mapListToCollectionEmptySet() {
+        CollSourceListNotAnnotated source = new CollSourceListNotAnnotated() {{
+            list.add(42L);
+            list.add(33L);
+        }};
+        CollTargetEmptyList target = beanMapper.map(source, CollTargetEmptyList.class);
+        assertNotSame("Source and Target list may not be the same, must be copied", source.list, target.list);
+        assertEquals(2, target.list.size());
+        assertEquals("42", target.list.get(0));
+        assertEquals("33", target.list.get(1));
+    }
+
+    @Test
+    public void mapNonAnnotatedListWithoutGenerics() {
+        CollSourceNoGenerics source = new CollSourceNoGenerics() {{
+            list.add("42");
+            list.add("33");
+        }};
+        CollTargetNoGenerics target = beanMapper.map(source, CollTargetNoGenerics.class);
+        assertSame("Source and Target list may not be the same, must be copied", source.list, target.list);
+        assertEquals(2, target.list.size());
+        assertEquals("42", target.list.get(0));
+        assertEquals("33", target.list.get(1));
     }
 
     @Test

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSourceNoGenerics.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSourceNoGenerics.java
@@ -1,0 +1,10 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollSourceNoGenerics {
+
+    public List list = new ArrayList();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSubTargetList.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSubTargetList.java
@@ -1,0 +1,3 @@
+package io.beanmapper.testmodel.collections;
+
+public class CollSubTargetList extends CollSuperTargetList {}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollSuperTargetList.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollSuperTargetList.java
@@ -1,0 +1,10 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollSuperTargetList {
+
+    public List<String> list = new ArrayList<>();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollTargetEmptyList.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollTargetEmptyList.java
@@ -1,0 +1,10 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CollTargetEmptyList {
+
+    public List<String> list = Collections.emptyList();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollTargetListNotAnnotatedUseSetter.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollTargetListNotAnnotatedUseSetter.java
@@ -1,0 +1,18 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CollTargetListNotAnnotatedUseSetter {
+
+    private List<String> list = new ArrayList<>();
+
+    public void setList(List<String> list) {
+        this.list = list;
+    }
+
+    public List<String> getList() {
+        return list;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollTargetNoGenerics.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollTargetNoGenerics.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.List;
+
+public class CollTargetNoGenerics {
+
+    public List list;
+
+}


### PR DESCRIPTION
Issue #99. Collections in superclasses did not get their generic types read. One of the attributes of getDeclaredField(field) is that it only works on the active class. The fix means that the superclasses will be checked for presence of the field. When found, it will call getDeclaredField on that class to get its generic type. Also, collection mapping instructions are not used when no collection element type can be determined; that is the one crucial element required for mapping collections.

Issue #100. Collections.EmptySet can not have add() called on. BeanCollectionUsage will check the canonical classname of the collection. If it starts with "java.util.Collections.", it will be tagged as reconstructable.