### PR TITLE
Fixed IllegalAccessExceptions that occurred after JMV garbage collection

### DIFF
--- a/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
@@ -23,7 +23,6 @@ public class FieldPropertyAccessor implements PropertyAccessor {
 
     public FieldPropertyAccessor(Field field) {
         this.field = field;
-        this.field.setAccessible(true);
     }
 
     /**
@@ -68,6 +67,7 @@ public class FieldPropertyAccessor implements PropertyAccessor {
     @Override
     public Object getValue(Object instance) {
         try {
+            field.setAccessible(true);
             return field.get(instance);
         } catch (IllegalAccessException e) {
             throw new BeanGetFieldException(instance.getClass(), field.getName(), e);
@@ -88,6 +88,7 @@ public class FieldPropertyAccessor implements PropertyAccessor {
     @Override
     public void setValue(Object instance, Object value) {
         try {
+            field.setAccessible(true);
             field.set(instance, value);
         } catch (IllegalAccessException e) {
             throw new BeanSetFieldException(instance.getClass(), field.getName(), e);

--- a/src/main/java/io/beanmapper/core/inspector/PropertyDescriptorPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/PropertyDescriptorPropertyAccessor.java
@@ -23,14 +23,6 @@ public class PropertyDescriptorPropertyAccessor implements PropertyAccessor {
 
     public PropertyDescriptorPropertyAccessor(PropertyDescriptor descriptor) {
         this.descriptor = descriptor;
-        makeAccessable(descriptor.getReadMethod());
-        makeAccessable(descriptor.getWriteMethod());
-    }
-    
-    private void makeAccessable(Method method) {
-        if (method != null) {
-            method.setAccessible(true);
-        }
     }
 
     /**
@@ -82,10 +74,10 @@ public class PropertyDescriptorPropertyAccessor implements PropertyAccessor {
         }
 
         try {
-            return descriptor.getReadMethod().invoke(instance);
-        } catch (IllegalAccessException e) {
-            throw new BeanGetFieldException(instance.getClass(), getName(), e);
-        } catch (InvocationTargetException e) {
+            Method readMethod = descriptor.getReadMethod();
+            readMethod.setAccessible(true);
+            return readMethod.invoke(instance);
+        } catch (IllegalAccessException | InvocationTargetException e) {
             throw new BeanGetFieldException(instance.getClass(), getName(), e);
         }
     }
@@ -108,10 +100,10 @@ public class PropertyDescriptorPropertyAccessor implements PropertyAccessor {
         }
         
         try {
-            descriptor.getWriteMethod().invoke(instance, value);
-        } catch (IllegalAccessException e) {
-            throw new BeanSetFieldException(instance.getClass(), getName(), e);
-        } catch (InvocationTargetException e) {
+            Method writeMethod = descriptor.getWriteMethod();
+            writeMethod.setAccessible(true);
+            writeMethod.invoke(instance, value);
+        } catch (IllegalAccessException | InvocationTargetException e) {
             throw new BeanSetFieldException(instance.getClass(), getName(), e);
         }
     }

--- a/src/test/java/io/beanmapper/core/inspector/PropertyDescriptorPropertyAccessorTest.java
+++ b/src/test/java/io/beanmapper/core/inspector/PropertyDescriptorPropertyAccessorTest.java
@@ -1,0 +1,59 @@
+package io.beanmapper.core.inspector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.beans.PropertyDescriptor;
+
+import io.beanmapper.exceptions.BeanGetFieldException;
+import io.beanmapper.exceptions.BeanSetFieldException;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JMockit.class)
+public class PropertyDescriptorPropertyAccessorTest {
+
+    @Test
+    public void getValueShouldThrowBeanGetFieldExceptionWhenFieldIsNotReadable(@Mocked PropertyDescriptor mockDescriptor) {
+        PropertyDescriptorPropertyAccessor accessor = new PropertyDescriptorPropertyAccessor(mockDescriptor);
+
+        new Expectations() {{
+            mockDescriptor.getReadMethod();
+            result = null;
+
+            mockDescriptor.getName();
+            result = "bla";
+        }};
+
+        try {
+            accessor.getValue("Instance");
+            fail();
+        } catch (BeanGetFieldException e) {
+            assertEquals("Not possible to get field java.lang.String.bla", e.getMessage());
+        }
+    }
+
+    @Test
+    public void setValueShouldThrowBeanGetFieldExceptionWhenFieldIsNotReadable(@Mocked PropertyDescriptor mockDescriptor) {
+        PropertyDescriptorPropertyAccessor accessor = new PropertyDescriptorPropertyAccessor(mockDescriptor);
+
+        new Expectations() {{
+            mockDescriptor.getWriteMethod();
+            result = null;
+
+            mockDescriptor.getName();
+            result = "bla";
+        }};
+
+        try {
+            accessor.setValue("Instance", "value");
+            fail();
+        } catch (BeanSetFieldException e) {
+            assertEquals("Not possible to set field java.lang.String.bla", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
An error sometimes occurred in the BeanMapper when it attempted to
invoke a getter method in the PropertyDescriptorPropertyAccessor.

The short version of the solution:

	The setAccessible method should be called very soon prior to calling
	the invoke method rather than only once at the creation of the
	PropertyDescriptorPropertyAccessor.

For the long version of the solution, let me take you down the
rabbit hole:

	The error occurred in the following piece of code, when the 'invoke'
	method was called:

	@Override
	public Object getValue(Object instance) {
	    if (!isReadable()) {
	        throw new BeanGetFieldException(instance.getClass(), getName());
	    }

	    try {
	        return descriptor.getReadMethod().invoke(instance);
	    } catch (IllegalAccessException e) {
	        throw new BeanGetFieldException(instance.getClass(), getName(), e);
	    } catch (InvocationTargetException e) {
	        throw new BeanGetFieldException(instance.getClass(), getName(), e);
	    }
	}

	This read method was made accessible in the constructor of the
	PropertyDescriptorPropertyAccessor:

	public PropertyDescriptorPropertyAccessor(PropertyDescriptor descriptor) {
	    this.descriptor = descriptor;
	    makeAccessable(descriptor.getReadMethod());
	    makeAccessable(descriptor.getWriteMethod());
	}

	private void makeAccessable(Method method) {
	    if (method != null) {
	        method.setAccessible(true);
	    }
	}

	And the PropertyDescriptorPropertyAccessor is only created once for each
	method and afterwards the same instance is used to retrieve the value
	from the appropriate method. This can be verified by checking its memory
	address.

	When the getReadMethod() is called on the descriptor, the same instance
	is returned from the memory. Or so it seems.

	When you step into the getReadMethod() you can see that it retrieves the
	read method from a reference:

	Method readMethod = this.readMethodRef.get();

	When we step into the get() method on the readMethodRef field,
	we see the following body:

	 Method get() {
	    if (this.methodRef == null) {
	        return null;
	    }
	    Method method = this.methodRef.get();
	    if (method == null) {
	        method = find(this.typeRef.get(), this.signature);
	        if (method == null) {
	            this.signature = null;
	            this.methodRef = null;
	            this.typeRef = null;
	        }
	        else {
	            this.methodRef = new SoftReference<>(method);
	        }
	    }
	    return isPackageAccessible(method.getDeclaringClass()) ? method : null;
	}

	A SoftReference is created if the current value of methodRef is null,
	the next time the same SoftReference instance is returned. On this
	SoftReference's referent object (which is an instance of Method)
	a setAccessible(true) call is done when the PropertyDescriptorPropertyAccessor
	is created.

	In the JavaDoc of a SoftReference, the following comment is shown:

	 * Soft reference objects, which are cleared at the discretion of the garbage
	 * collector in response to memory demand.  Soft references are most often used
	 * to implement memory-sensitive caches.

	It seems that at some point in time the reference is deleted when the garbage
	collector decides it is time. Then, a new reference is created for which the
	setAccessible method has NOT been called. This results in an
	IllegalAccessException and halts the mapping.

	When we call setAccessible just before we call the invoke, we set the accessibility
	on the SoftReference we just got back or created. The garbage collector can not clean
	this up in the meantime as we still have a reference to it.

	The same fix was performed for both field and and method accessors.