### PR TITLE
Specify the return type for AbstractBeanConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Enhanced
+- Issue [#109](https://github.com/42BV/beanmapper/issues/109), **Specify the return type for AbstractBeanConverter.doConvert**; on extending AbstractBeanConverter, it is beneficial for the developer to immediately see the expected return type for the ```doConvert``` method.
 
 ## [2.4.0] - 2018-03-28
 ### Added

--- a/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
@@ -63,7 +63,7 @@ public abstract class AbstractBeanConverter<S, T> implements BeanConverter {
      * @param targetClass the class type to convert to
      * @return the converted source instance
      */
-    protected abstract Object doConvert(S source, Class<? extends T> targetClass);
+    protected abstract T doConvert(S source, Class<? extends T> targetClass);
 
     /**
      * {@inheritDoc}

--- a/src/main/java/io/beanmapper/core/converter/SimpleBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/SimpleBeanConverter.java
@@ -34,7 +34,7 @@ public abstract class SimpleBeanConverter<S, T> extends AbstractBeanConverter<S,
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected final Object doConvert(S source, Class<? extends T> targetClass) {
+    protected final T doConvert(S source, Class<? extends T> targetClass) {
         return doConvert(source); // No need to provide the target class
     }
     

--- a/src/main/java/io/beanmapper/core/converter/impl/AnyToEnumConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/AnyToEnumConverter.java
@@ -18,7 +18,7 @@ public class AnyToEnumConverter extends AbstractBeanConverter<Object, Enum<?>> {
     }
 
     @Override
-    protected Object doConvert(Object source, Class<? extends Enum<?>> targetClass) {
+    protected Enum<?> doConvert(Object source, Class<? extends Enum<?>> targetClass) {
         if (source == null) {
             return null;
         }


### PR DESCRIPTION
Literally changed return type Object on doConvert to T. All extensions
will pick up this specification, making it clearer to the using developer 
what return type is expected.