### PR TITLE
Use null source collection and enforce build sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Enhanced
 - Issue [#109](https://github.com/42BV/beanmapper/issues/109), **Specify the return type for AbstractBeanConverter.doConvert**; on extending AbstractBeanConverter, it is beneficial for the developer to immediately see the expected return type for the ```doConvert``` method.
+- Bug [#111](https://github.com/42BV/beanmapper/issues/111), **BeanCollection null list overrides the existing list**; when a source and target have been assigned to a collection handler, it will now treat a null value for the source as special, subscribing it to the BeanCollectionUsage rules (default: CLEAR). That is, it will REUSE the target, CLEAR it, or CONSTRUCT a new one. This is the most logical behaviour with Hibernate on the other side. 
+- Bug [#112](https://github.com/42BV/beanmapper/issues/112), **Strict mapping messes up the build sequence**; The validation took place before all configuration was done, resulting in collection handlers not being available in some cases. The validation of strict classes is done as part of the last step of the ```BeanMapperBuilder.build()``` method, after all required steps have been taken.
 
 ## [2.4.0] - 2018-03-28
 ### Added

--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import io.beanmapper.config.BeanMapperBuilder;
 import io.beanmapper.config.Configuration;
-import io.beanmapper.config.CoreConfiguration;
 import io.beanmapper.strategy.MapStrategyType;
 
 /**
@@ -17,14 +16,14 @@ import io.beanmapper.strategy.MapStrategyType;
 @SuppressWarnings("unchecked")
 public class BeanMapper {
 
-    private Configuration configuration = new CoreConfiguration();
+    private final Configuration configuration;
 
     public BeanMapper(Configuration configuration) {
         this.configuration = configuration;
     }
 
     public Object map(Object source) {
-        if (source == null) {
+        if (source == null && !configuration.getUseNullValue()) {
             return null;
         }
         return MapStrategyType.getStrategy(this, configuration).map(source);

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -188,10 +188,14 @@ public class BeanMapperBuilder {
         return this;
     }
 
+
+    public BeanMapperBuilder setUseNullValue() {
+        this.configuration.setUseNullValue(true);
+        return this;
+    }
+
     public BeanMapper build() {
         BeanMapper beanMapper = new BeanMapper(configuration);
-        // Make sure all strict bean classes have matching properties on the other side
-        configuration.getBeanMatchStore().validateStrictBeanPairs(configuration.getBeanPairs());
         // Custom collection handlers must be registered before default ones
         addCollectionHandlers(customCollectionHandlers);
         addCollectionHandlers(DEFAULT_COLLECTION_HANDLERS);
@@ -200,6 +204,8 @@ public class BeanMapperBuilder {
         if (configuration.isAddDefaultConverters()) {
             addDefaultConverters();
         }
+        // Make sure all strict bean classes have matching properties on the other side
+        configuration.getBeanMatchStore().validateStrictBeanPairs(configuration.getBeanPairs());
         return beanMapper;
     }
 

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -192,6 +192,12 @@ public interface Configuration {
     Boolean mustFlush();
 
     /**
+     * Property that determines if null values for the source must be skipped or not
+     * @return determines if null values must be skipped or not
+     */
+    Boolean getUseNullValue();
+
+    /**
      * The RoleSecuredCheck is responsible for checking if a Principal may access
      * a field or method annotated with @BeanRoleSecured. Returns the RoleSecuredCheck,
      * if it has been configured.
@@ -406,5 +412,11 @@ public interface Configuration {
      * @param enforceSecuredProperties whether the handling of secured properties is enforced
      */
     void setEnforceSecuredProperties(Boolean enforceSecuredProperties);
+
+    /**
+     * Property that determines if null values for the source must be skipped or not
+     * @param useNullValue determines if null values must be skipped or not
+     */
+    void setUseNullValue(Boolean useNullValue);
 
 }

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -93,6 +93,12 @@ public class CoreConfiguration implements Configuration {
      */
     private Boolean enforceSecuredProperties = true;
 
+    /**
+     * Property that determines if null values for the source will be used. Normal behaviour
+     * is to skip the mapping operation if a source value is null.
+     */
+    private Boolean useNullValue = false;
+
     @Override
     public List<String> getDownsizeTarget() { return null; }
 
@@ -231,6 +237,11 @@ public class CoreConfiguration implements Configuration {
     @Override
     public Boolean mustFlush() {
         return false;
+    }
+
+    @Override
+    public Boolean getUseNullValue() {
+        return this.useNullValue;
     }
 
     @Override
@@ -396,6 +407,11 @@ public class CoreConfiguration implements Configuration {
     @Override
     public void setEnforceSecuredProperties(Boolean enforceSecuredProperties) {
         this.enforceSecuredProperties = enforceSecuredProperties;
+    }
+
+    @Override
+    public void setUseNullValue(Boolean useNullValue) {
+        this.useNullValue = useNullValue;
     }
 
 }

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -45,6 +45,8 @@ public class OverrideConfiguration implements Configuration {
 
     private Boolean enforcedSecuredProperties = null;
 
+    private OverrideField<Boolean> useNullValue;
+
     private OverrideField<Boolean> flushAfterClear;
 
     private OverrideField<Boolean> flushEnabled;
@@ -61,6 +63,7 @@ public class OverrideConfiguration implements Configuration {
         this.converterChoosable = new OverrideField<>(configuration::isConverterChoosable);
         this.flushAfterClear = new OverrideField<>(configuration::isFlushAfterClear);
         this.flushEnabled = new OverrideField<>(configuration::isFlushEnabled);
+        this.useNullValue = new OverrideField<>(configuration::getUseNullValue);
     }
 
     @Override
@@ -228,6 +231,11 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
+    public Boolean getUseNullValue() {
+        return useNullValue.get();
+    }
+
+    @Override
     public RoleSecuredCheck getRoleSecuredCheck() {
         return parentConfiguration.getRoleSecuredCheck();
     }
@@ -382,6 +390,11 @@ public class OverrideConfiguration implements Configuration {
     @Override
     public void setFlushEnabled(Boolean flushEnabled) {
         this.flushEnabled.set(flushEnabled);
+    }
+
+    @Override
+    public void setUseNullValue(Boolean useNullValue) {
+        this.useNullValue.set(useNullValue);
     }
 
 }

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -33,6 +33,7 @@ public class CollectionConverter<T> implements BeanConverter {
                 .setFlushAfterClear(beanFieldMatch.getCollectionInstructions().getFlushAfterClear())
                 .setTargetClass(beanFieldMatch.getCollectionInstructions().getCollectionElementType().getType())
                 .setTarget(beanFieldMatch.getTargetObject())
+                .setUseNullValue()
                 .build()
                 .map(sourceCollection);
     }

--- a/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
@@ -9,6 +9,7 @@ import io.beanmapper.config.Configuration;
 import io.beanmapper.core.BeanFieldMatch;
 import io.beanmapper.core.BeanMatch;
 import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.core.converter.collections.CollectionConverter;
 import io.beanmapper.exceptions.BeanConversionException;
 import io.beanmapper.exceptions.BeanFieldNoMatchException;
 
@@ -118,13 +119,15 @@ public abstract class AbstractMapStrategy implements MapStrategy {
      */
     @SuppressWarnings("unchecked")
     public Object convert(Object value, Class<?> targetClass, BeanFieldMatch beanFieldMatch) {
-        if (value == null) {
+
+        Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(beanFieldMatch.getSourceClass());
+        BeanConverter converter = getConverterOptional(valueClass, targetClass);
+
+        // @TODO Consider removing the null check here and offering a null value to BeanConverters as well
+        if (value == null && !(converter instanceof CollectionConverter)) {
             return null;
         }
 
-        Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(value.getClass());
-
-        BeanConverter converter = getConverterOptional(valueClass, targetClass);
         if (converter != null) {
             logger.debug(INDENT + converter.getClass().getSimpleName() + ARROW);
             BeanMapper wrappedBeanMapper = beanMapper

--- a/src/main/java/io/beanmapper/strategy/MapCollectionStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapCollectionStrategy.java
@@ -25,13 +25,15 @@ public class MapCollectionStrategy extends AbstractMapStrategy {
             this.getConfiguration().mustFlush()
         );
 
-        targetItems = collectionHandler.copy(
+        if (source == null) {
+            return targetItems;
+        }
+
+        return collectionHandler.copy(
                 getBeanMapper(),
                 getConfiguration().getTargetClass(),
                 source,
                 targetItems);
-
-        return targetItems;
     }
 
 }

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -1279,25 +1279,37 @@ public class BeanMapperTest {
     @Test
     public void beanCollectionClearEmptySource() {
         CollSourceClear source = new CollSourceClear();
+        CollTarget target = new CollTarget();
+        List<String> targetItems = target.items;
+        targetItems.add("Alpha");
         source.items = null;
-        CollTarget target = beanMapper.map(source, CollTarget.class);
-        assertNull(target.items);
+        target = beanMapper.map(source, target);
+        assertEquals(targetItems, target.items);
+        assertEquals(0, target.items.size());
     }
 
     @Test
     public void beanCollectionReuseEmptySource() {
         CollSourceReuse source = new CollSourceReuse();
+        CollTarget target = new CollTarget();
+        List<String> targetItems = target.items;
+        targetItems.add("Alpha");
         source.items = null;
-        CollTarget target = beanMapper.map(source, CollTarget.class);
-        assertNull(target.items);
+        target = beanMapper.map(source, target);
+        assertEquals(targetItems, target.items);
+        assertEquals(1, target.items.size());
     }
 
     @Test
     public void beanCollectionConstructEmptySource() {
         CollSourceConstruct source = new CollSourceConstruct();
+        CollTarget target = new CollTarget();
+        List<String> targetItems = target.items;
+        targetItems.add("Alpha");
         source.items = null;
-        CollTarget target = beanMapper.map(source, CollTarget.class);
-        assertNull(target.items);
+        target = beanMapper.map(source, target);
+        assertNotSame(targetItems, target.items);
+        assertEquals(0, target.items.size());
     }
 
     @Test
@@ -1569,9 +1581,10 @@ public class BeanMapperTest {
     }
 
     @Test
-    public void unwrappedToWrappedTest() {
+    public void unwrappedToWrapped() {
         BeanMapper beanMapper = new BeanMapperBuilder()
                 .addConverter(new UnwrappedToWrappedBeanConverter())
+                .addBeanPairWithStrictSource(SourceWithUnwrappedItems.class, TargetWithWrappedItems.class)
                 .build();
         SourceWithUnwrappedItems source = new SourceWithUnwrappedItems();
         source.items.add(UnwrappedSource.BETA);
@@ -1584,6 +1597,19 @@ public class BeanMapperTest {
         assertEquals(source.items.get(0), target.getItems().get(0).getElement());
         assertEquals(source.items.get(1), target.getItems().get(1).getElement());
         assertEquals(source.items.get(2), target.getItems().get(2).getElement());
+    }
+
+    @Test
+    public void emptyListToExistingList() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .addConverter(new UnwrappedToWrappedBeanConverter())
+                .build();
+        SourceWithUnwrappedItems source = new SourceWithUnwrappedItems();
+        source.items = null;
+        TargetWithWrappedItems target = new TargetWithWrappedItems();
+        List<WrappedTarget> targetItems = target.getItems();
+        target = beanMapper.map(source, target);
+        assertEquals(targetItems, target.getItems());
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/testmodel/collections/CollTarget.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollTarget.java
@@ -1,9 +1,10 @@
 package io.beanmapper.testmodel.collections;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CollTarget {
 
-    public List<String> items;
+    public List<String> items = new ArrayList<>();
 
 }


### PR DESCRIPTION
Bug #111; when a source and target have been assigned to a collection
 handler, it will now treat a null value for the source as special,
 subscribing it to the BeanCollectionUsage rules (default: CLEAR).
 That is, it will REUSE the target, CLEAR it, or CONSTRUCT a new one.
 This is the most logical behaviour with Hibernate on the other side.

Bug #112 The validation took place before all configuration was done,
 resulting in collection handlers not being available in some cases.
 The validation of strict classes is done as part of the last step of
 the ```BeanMapperBuilder.build()``` method, after all required steps
 have been taken.