### PR TITLE
#116 Mappable nested classes analyzed for wrong direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Fixed
+- Issue [#116](https://github.com/42BV/beanmapper/issues/116), **Mappable nested classes analyzed for wrong direction**; when dealing with a mappable nested class, the applied direction is used as-is. This resulted in errors when the field could only be accessed through a method accessor and that the complementing method accessor was not available (ie, get and no set, or set and no get). The problem has been fixed by inverting the method direction on dealing with a mappable nested class.
 
 ## [3.0.0] - 2018-07-17
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.beanmapper</groupId>
     <artifactId>beanmapper</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>42 Bean Mapper</name>
     <description>Easy-to-use bean mapper for conversion from form to object to view</description>

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -265,8 +265,8 @@ public class BeanMatchStore {
             try {
                 otherNodes.put(
                         wrapper.getName(),
-                        new BeanPropertyCreator(
-                                matchupDirection, otherType, wrapper.getName()).determineNodesForPath());
+                        new BeanPropertyCreator(matchupDirection.getInverse(), otherType, wrapper.getName())
+                            .determineNodesForPath());
             } catch (BeanNoSuchPropertyException err) {
                 // Acceptable, might have been tagged as @BeanProperty as well
             }

--- a/src/main/java/io/beanmapper/core/BeanPropertyMatchupDirection.java
+++ b/src/main/java/io/beanmapper/core/BeanPropertyMatchupDirection.java
@@ -29,6 +29,10 @@ public enum BeanPropertyMatchupDirection {
         }
     };
 
+    public BeanPropertyMatchupDirection getInverse() {
+        return values()[(values().length - 1) - ordinal()];
+    }
+
     public abstract BeanPropertyAccessType accessType(PropertyAccessor accessor);
 
     public abstract boolean checkFieldForCollectionProperty();

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -132,6 +132,10 @@ import io.beanmapper.testmodel.nested_classes.Layer1;
 import io.beanmapper.testmodel.nested_classes.Layer1Result;
 import io.beanmapper.testmodel.nested_classes.Layer3;
 import io.beanmapper.testmodel.nested_classes.Layer4;
+import io.beanmapper.testmodel.not_accessible.source_contains_nested_class.TargetWithPersonName;
+import io.beanmapper.testmodel.not_accessible.source_contains_nested_class.SourceWithPerson;
+import io.beanmapper.testmodel.not_accessible.target_contains_nested_class.SourceWithPersonName;
+import io.beanmapper.testmodel.not_accessible.target_contains_nested_class.TargetWithPerson;
 import io.beanmapper.testmodel.numbers.ClassWithInteger;
 import io.beanmapper.testmodel.numbers.ClassWithLong;
 import io.beanmapper.testmodel.numbers.SourceWithDouble;
@@ -1610,6 +1614,21 @@ public class BeanMapperTest {
         List<WrappedTarget> targetItems = target.getItems();
         target = beanMapper.map(source, target);
         assertEquals(targetItems, target.getItems());
+    }
+
+    @Test
+    public void useBeanPropertyPathToAccessGetterOnly() {
+        SourceWithPerson source = new SourceWithPerson();
+        TargetWithPersonName target = beanMapper.map(source, TargetWithPersonName.class);
+        assertEquals(source.person.getFullName(), target.name);
+    }
+
+    @Test
+    public void useBeanPropertyPathToAccessSetterOnly() {
+        SourceWithPersonName source = new SourceWithPersonName();
+        source.name = "Zeefod Beeblebrox";
+        TargetWithPerson target = beanMapper.map(source, TargetWithPerson.class);
+        assertEquals(source.name, target.person.result);
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/testmodel/not_accessible/source_contains_nested_class/PersonWithGetterOnlyProperty.java
+++ b/src/test/java/io/beanmapper/testmodel/not_accessible/source_contains_nested_class/PersonWithGetterOnlyProperty.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.not_accessible.source_contains_nested_class;
+
+public class PersonWithGetterOnlyProperty {
+
+    public String getFullName() {
+        return "Zeefod Beeblebrox";
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/not_accessible/source_contains_nested_class/SourceWithPerson.java
+++ b/src/test/java/io/beanmapper/testmodel/not_accessible/source_contains_nested_class/SourceWithPerson.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.not_accessible.source_contains_nested_class;
+
+public class SourceWithPerson {
+
+    public PersonWithGetterOnlyProperty person = new PersonWithGetterOnlyProperty();
+
+}

--- a/src/test/java/io/beanmapper/testmodel/not_accessible/source_contains_nested_class/TargetWithPersonName.java
+++ b/src/test/java/io/beanmapper/testmodel/not_accessible/source_contains_nested_class/TargetWithPersonName.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.not_accessible.source_contains_nested_class;
+
+import io.beanmapper.annotations.BeanProperty;
+
+public class TargetWithPersonName {
+
+    @BeanProperty(name = "person.fullName")
+    public String name;
+
+
+}

--- a/src/test/java/io/beanmapper/testmodel/not_accessible/target_contains_nested_class/PersonWithSetterOnlyProperty.java
+++ b/src/test/java/io/beanmapper/testmodel/not_accessible/target_contains_nested_class/PersonWithSetterOnlyProperty.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.not_accessible.target_contains_nested_class;
+
+public class PersonWithSetterOnlyProperty {
+
+    public String result;
+
+    public void setFullName(String fullName) {
+        this.result = fullName;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/not_accessible/target_contains_nested_class/SourceWithPersonName.java
+++ b/src/test/java/io/beanmapper/testmodel/not_accessible/target_contains_nested_class/SourceWithPersonName.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.not_accessible.target_contains_nested_class;
+
+import io.beanmapper.annotations.BeanProperty;
+
+public class SourceWithPersonName {
+
+    @BeanProperty(name = "person.fullName")
+    public String name;
+
+
+}

--- a/src/test/java/io/beanmapper/testmodel/not_accessible/target_contains_nested_class/TargetWithPerson.java
+++ b/src/test/java/io/beanmapper/testmodel/not_accessible/target_contains_nested_class/TargetWithPerson.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.not_accessible.target_contains_nested_class;
+
+public class TargetWithPerson {
+
+    public PersonWithSetterOnlyProperty person = new PersonWithSetterOnlyProperty();
+
+}


### PR DESCRIPTION
On dealing with mappable nested classes in combination with a
@BeanProperty dot-delimited route, the wrong mapping direction
was applied. This resulted in errors at the moment that the field
could only be accessed through a method accessor and that the
complementing method accessor was not available (ie, get and no set,
or set and no get).

The problem has been fixed by inverting the method direction on
dealing with a mappable nested class.