### PR TITLE
#118 Nested ParameterizedTypes throws a ClassCastException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Fixed
+- Issue [#118](https://github.com/42BV/beanmapper/issues/118), **Nested ParameterizedTypes throws a ClassCastException**; when a type is a nested generic (eg, List<List<String>>) it threw a ClassCastException, even if no mapping took place. Fixed by checking the Type in ```AbstractBeanPropertyClass``` and calling for rawType if it concerns a ParameterizedType.
 - Issue [#116](https://github.com/42BV/beanmapper/issues/116), **Mappable nested classes analyzed for wrong direction**; when dealing with a mappable nested class, the applied direction is used as-is. This resulted in errors when the field could only be accessed through a method accessor and that the complementing method accessor was not available (ie, get and no set, or set and no get). The problem has been fixed by inverting the method direction on dealing with a mappable nested class.
 
 ## [3.0.0] - 2018-07-17

--- a/src/main/java/io/beanmapper/core/generics/AbstractBeanPropertyClass.java
+++ b/src/main/java/io/beanmapper/core/generics/AbstractBeanPropertyClass.java
@@ -1,5 +1,6 @@
 package io.beanmapper.core.generics;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
 abstract class AbstractBeanPropertyClass implements BeanPropertyClass {
@@ -8,7 +9,15 @@ abstract class AbstractBeanPropertyClass implements BeanPropertyClass {
         if (index >= getGenericTypes().length) {
             return null;
         }
-        return (Class<?>)getGenericTypes()[index];
+        return convertToClass(getGenericTypes()[index]);
+    }
+
+    public Class<?> convertToClass(Type type) {
+        if (type instanceof ParameterizedType) {
+            return (Class<?>)((ParameterizedType)type).getRawType();
+        } else {
+            return (Class<?>)type;
+        }
     }
 
     protected abstract Type[] getGenericTypes();

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -2,6 +2,7 @@ package io.beanmapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -132,6 +133,8 @@ import io.beanmapper.testmodel.nested_classes.Layer1;
 import io.beanmapper.testmodel.nested_classes.Layer1Result;
 import io.beanmapper.testmodel.nested_classes.Layer3;
 import io.beanmapper.testmodel.nested_classes.Layer4;
+import io.beanmapper.testmodel.nested_generics.SourceWithNestedGenerics;
+import io.beanmapper.testmodel.nested_generics.TargetWithNestedGenerics;
 import io.beanmapper.testmodel.not_accessible.source_contains_nested_class.TargetWithPersonName;
 import io.beanmapper.testmodel.not_accessible.source_contains_nested_class.SourceWithPerson;
 import io.beanmapper.testmodel.not_accessible.target_contains_nested_class.SourceWithPersonName;
@@ -1629,6 +1632,13 @@ public class BeanMapperTest {
         source.name = "Zeefod Beeblebrox";
         TargetWithPerson target = beanMapper.map(source, TargetWithPerson.class);
         assertEquals(source.name, target.person.result);
+    }
+
+    @Test
+    public void nestedGenericsEmptyList() {
+        SourceWithNestedGenerics source = new SourceWithNestedGenerics();
+        TargetWithNestedGenerics target = beanMapper.map(source, TargetWithNestedGenerics.class);
+        assertNotNull(target.names);
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/testmodel/nested_generics/SourceWithNestedGenerics.java
+++ b/src/test/java/io/beanmapper/testmodel/nested_generics/SourceWithNestedGenerics.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.nested_generics;
+
+import java.util.List;
+
+public class SourceWithNestedGenerics {
+    public List<List<String>> names;
+}

--- a/src/test/java/io/beanmapper/testmodel/nested_generics/TargetWithNestedGenerics.java
+++ b/src/test/java/io/beanmapper/testmodel/nested_generics/TargetWithNestedGenerics.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.nested_generics;
+
+import java.util.List;
+
+public class TargetWithNestedGenerics {
+    public List<List<String>> names;
+}


### PR DESCRIPTION
When a type is a nested generic (eg, List<List<String>>) it threw a
ClassCastException, even if no mapping took place. Fixed by checking
the Type in ```AbstractBeanPropertyClass``` and calling for rawType
if it concerns a ParameterizedType.