### PR TITLE
Added value alias for @BeanProperty

### DIFF
--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -110,6 +110,7 @@ public class BeanMapper {
 
     /**
      * @deprecated use wrap() instead
+     * @return BeanMapperBuilder
      */
     public BeanMapperBuilder config() {
         return wrap();
@@ -117,6 +118,7 @@ public class BeanMapper {
 
     /**
      * @deprecated use wrap() instead
+     * @return BeanMapperBuilder
      */
     public BeanMapperBuilder wrapConfig() {
         return wrap();

--- a/src/main/java/io/beanmapper/annotations/BeanCollection.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollection.java
@@ -51,6 +51,7 @@ public @interface BeanCollection {
      * functionality in combination with Lazy to make sure BeanMapper operates within the
      * transaction scope. If you do, the flush action can be rolled back, resulting in the
      * original state being preserved.
+     * @return Whether to flush the collection after clearing or not.
      */
     boolean flushAfterClear() default true;
 

--- a/src/main/java/io/beanmapper/annotations/BeanProperty.java
+++ b/src/main/java/io/beanmapper/annotations/BeanProperty.java
@@ -13,6 +13,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BeanProperty {
 
-    String name();
+    String name() default "";
+
+    String value() default "";
 
 }

--- a/src/main/java/io/beanmapper/annotations/BeanRoleSecured.java
+++ b/src/main/java/io/beanmapper/annotations/BeanRoleSecured.java
@@ -15,6 +15,7 @@ public @interface BeanRoleSecured {
 
     /**
      * The role the Principal must have to be allowed access to the field or method
+     * @return Role required to access the field or method
      */
     String[] value();
 

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -259,7 +259,7 @@ public class BeanMatchStore {
         BeanPropertyWrapper wrapper = new BeanPropertyWrapper(accessor.getName());
         if (accessor.findAnnotation(io.beanmapper.annotations.BeanProperty.class) != null) {
             wrapper.setMustMatch();
-            wrapper.setName(accessor.findAnnotation(io.beanmapper.annotations.BeanProperty.class).name());
+            wrapper.setName(getBeanPropertyName(accessor.findAnnotation(io.beanmapper.annotations.BeanProperty.class)));
             // Get the other field from the location that is specified in the beanProperty annotation.
             // If the field is referred to by a path, store the custom field in the other map
             try {
@@ -272,6 +272,16 @@ public class BeanMatchStore {
             }
         }
         return wrapper;
+    }
+
+    private String getBeanPropertyName(io.beanmapper.annotations.BeanProperty annotation) {
+        String beanPropertyName = annotation.value();
+
+        if (beanPropertyName.isEmpty()) {
+            beanPropertyName = annotation.name();
+        }
+
+        return beanPropertyName;
     }
 
 }

--- a/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
@@ -24,7 +24,7 @@ public abstract class AbstractCollectionHandler<C> implements CollectionHandler<
 
     /**
      * Creates a new instance of the collection class
-     * @return
+     * @return new instance of the collection class
      */
     abstract protected C create();
 

--- a/src/test/java/io/beanmapper/testmodel/othername/SourceWithOtherName.java
+++ b/src/test/java/io/beanmapper/testmodel/othername/SourceWithOtherName.java
@@ -4,7 +4,7 @@ import io.beanmapper.annotations.BeanProperty;
 
 public class SourceWithOtherName {
 
-    @BeanProperty(name = "bothOtherName")
+    @BeanProperty("bothOtherName")
     private String bothOtherName1;
     @BeanProperty(name = "sourceOtherName")
     private String sourceOtherName1;


### PR DESCRIPTION
`@BeanProperty` could only be used with a `name` property. Adding a
`value` alias allows this annotation to be used without any prefix and
just the name of the property.

Also corrected all warnings about javadoc (missing returns).

Fixes #122