### PR TITLE
Allowing the client to let beanmapper map null collections to null co…

### DIFF
--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -194,6 +194,16 @@ public class BeanMapperBuilder {
         return this;
     }
 
+    public BeanMapperBuilder setUseNullValue(boolean useNullValue) {
+        this.configuration.setUseNullValue(useNullValue);
+        return this;
+    }
+
+    public BeanMapperBuilder setUseCollectionNullValue(boolean useCollectionNullValue) {
+        this.configuration.setUseCollectionNullValue(useCollectionNullValue);
+        return this;
+    }
+
     public BeanMapper build() {
         BeanMapper beanMapper = new BeanMapper(configuration);
         // Custom collection handlers must be registered before default ones

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -198,6 +198,12 @@ public interface Configuration {
     Boolean getUseNullValue();
 
     /**
+     * Property that determines if null values for the source collection must be skipped or not
+     * @return determines if null values must be skipped or not
+     */
+    Boolean getUseCollectionNullValue();
+
+    /**
      * The RoleSecuredCheck is responsible for checking if a Principal may access
      * a field or method annotated with @BeanRoleSecured. Returns the RoleSecuredCheck,
      * if it has been configured.
@@ -419,4 +425,9 @@ public interface Configuration {
      */
     void setUseNullValue(Boolean useNullValue);
 
+    /**
+     * Property that determines if null values for the source collections must be skipped or not
+     * @param useNullValue determines if null values must be skipped or not
+     */
+    void setUseCollectionNullValue(Boolean useNullValue);
 }

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -99,6 +99,12 @@ public class CoreConfiguration implements Configuration {
      */
     private Boolean useNullValue = false;
 
+    /**
+     * Property that determines if null collections should be mapped to an empty collection or a null value. Normal
+     * behaviour is to create an empty list if a source value is null.
+     */
+    private Boolean useCollectionNullValues = true;
+
     @Override
     public List<String> getDownsizeTarget() { return null; }
 
@@ -242,6 +248,11 @@ public class CoreConfiguration implements Configuration {
     @Override
     public Boolean getUseNullValue() {
         return this.useNullValue;
+    }
+
+    @Override
+    public Boolean getUseCollectionNullValue() {
+        return this.useCollectionNullValues;
     }
 
     @Override
@@ -414,4 +425,8 @@ public class CoreConfiguration implements Configuration {
         this.useNullValue = useNullValue;
     }
 
+    @Override
+    public void setUseCollectionNullValue(Boolean useNullValue) {
+        this.useCollectionNullValues = useNullValue;
+    }
 }

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -47,6 +47,8 @@ public class OverrideConfiguration implements Configuration {
 
     private OverrideField<Boolean> useNullValue;
 
+    private OverrideField<Boolean> useCollectionNullValue;
+
     private OverrideField<Boolean> flushAfterClear;
 
     private OverrideField<Boolean> flushEnabled;
@@ -64,6 +66,7 @@ public class OverrideConfiguration implements Configuration {
         this.flushAfterClear = new OverrideField<>(configuration::isFlushAfterClear);
         this.flushEnabled = new OverrideField<>(configuration::isFlushEnabled);
         this.useNullValue = new OverrideField<>(configuration::getUseNullValue);
+        this.useCollectionNullValue = new OverrideField<>(configuration::getUseCollectionNullValue);
     }
 
     @Override
@@ -236,6 +239,11 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
+    public Boolean getUseCollectionNullValue() {
+        return useCollectionNullValue.get();
+    }
+
+    @Override
     public RoleSecuredCheck getRoleSecuredCheck() {
         return parentConfiguration.getRoleSecuredCheck();
     }
@@ -395,6 +403,11 @@ public class OverrideConfiguration implements Configuration {
     @Override
     public void setUseNullValue(Boolean useNullValue) {
         this.useNullValue.set(useNullValue);
+    }
+
+    @Override
+    public void setUseCollectionNullValue(Boolean useNullValue) {
+        this.useCollectionNullValue.set(useNullValue);
     }
 
 }

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -33,7 +33,7 @@ public class CollectionConverter<T> implements BeanConverter {
                 .setFlushAfterClear(beanPropertyMatch.getCollectionInstructions().getFlushAfterClear())
                 .setTargetClass(beanPropertyMatch.getCollectionInstructions().getCollectionElementType().getType())
                 .setTarget(beanPropertyMatch.getTargetObject())
-                .setUseNullValue()
+                .setUseNullValue(beanMapper.getConfiguration().getUseCollectionNullValue())
                 .build()
                 .map(sourceCollection);
     }

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -1620,6 +1620,17 @@ public class BeanMapperTest {
     }
 
     @Test
+    public void nullListToNullList() {
+        BeanMapper beanMapper = new BeanMapperBuilder()
+                .setUseCollectionNullValue(false)
+                .build();
+        CollectionListSource source = new CollectionListSource();
+        source.items = null;
+        CollectionListTarget target = beanMapper.map(source, CollectionListTarget.class);
+        assertNull(target.items);
+    }
+
+    @Test
     public void useBeanPropertyPathToAccessGetterOnly() {
         SourceWithPerson source = new SourceWithPerson();
         TargetWithPersonName target = beanMapper.map(source, TargetWithPersonName.class);


### PR DESCRIPTION
…llections

Currently, beanmapper always maps null collections to empty collections. Setting useCollectionNullValues to false will map null collections to null collections.