### PR TITLE
#135 Enum to same enum conversions

### DIFF
--- a/src/main/java/io/beanmapper/core/converter/impl/AnyToEnumConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/AnyToEnumConverter.java
@@ -22,6 +22,9 @@ public class AnyToEnumConverter extends AbstractBeanConverter<Object, Enum<?>> {
         if (source == null) {
             return null;
         }
+        if (targetClass.isInstance(source)) {
+            return (Enum<?>)source;
+        }
         String sourceText = source.toString();
         if (isNotEmpty(sourceText)) {
             return valueOf(targetClass, sourceText);

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -113,14 +113,7 @@ import io.beanmapper.testmodel.encapsulate.ResultOneToMany;
 import io.beanmapper.testmodel.encapsulate.source_annotated.Car;
 import io.beanmapper.testmodel.encapsulate.source_annotated.CarDriver;
 import io.beanmapper.testmodel.encapsulate.source_annotated.Driver;
-import io.beanmapper.testmodel.enums.ColorEntity;
-import io.beanmapper.testmodel.enums.ColorResult;
-import io.beanmapper.testmodel.enums.ColorStringResult;
-import io.beanmapper.testmodel.enums.EnumSourceArraysAsList;
-import io.beanmapper.testmodel.enums.EnumTargetList;
-import io.beanmapper.testmodel.enums.RGB;
-import io.beanmapper.testmodel.enums.UserRole;
-import io.beanmapper.testmodel.enums.UserRoleResult;
+import io.beanmapper.testmodel.enums.*;
 import io.beanmapper.testmodel.ignore.IgnoreSource;
 import io.beanmapper.testmodel.ignore.IgnoreTarget;
 import io.beanmapper.testmodel.initially_unmatched_source.SourceWithUnmatchedField;
@@ -1624,6 +1617,14 @@ public class BeanMapperTest {
         assertEquals(CountryEnum.NL.getCode(), target.country.code);
         assertEquals(CountryEnum.NL.getDisplayName(), target.country.displayName);
         assertEquals(CountryEnum.NL.getImage(), target.country.image);
+    }
+
+    @Test
+    public void mapEnumWithToString() {
+        SourceWithEnumWithToString source = new SourceWithEnumWithToString();
+        source.myEnum = EnumWithToString.SOME_VALUE;
+        TargetWithEnumWithToString target = beanMapper.map(source, TargetWithEnumWithToString.class);
+        assertEquals(EnumWithToString.SOME_VALUE, target.myEnum);
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/testmodel/enums/EnumWithToString.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/EnumWithToString.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.enums;
+
+public enum EnumWithToString {
+    SOME_VALUE;
+
+    public String toString() {
+        return "X" + name() + "X";
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/SourceWithEnumWithToString.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/SourceWithEnumWithToString.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.enums;
+
+public class SourceWithEnumWithToString {
+    public EnumWithToString myEnum;
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/TargetWithEnumWithToString.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/TargetWithEnumWithToString.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.enums;
+
+public class TargetWithEnumWithToString {
+    public EnumWithToString myEnum;
+}


### PR DESCRIPTION
When performing a conversion from an enum to the same enum, the
AnyToEnumConverter is triggered, which performs a full cycle conversion,
using the toString() method of source and the valueOf() of the target
enum.

When the source enum is the same as the target enum and the source enum
has an overridden toString() method, this fails because the value can
not be mapped to the enum.

Instead, the AnyToEnumConverter now checks whether the source is of the
same enum class as the target. If this is the case, the conversion task
is skipped and the source is returned literally.