### PR TITLE
Reverted changes in AbstractConcurrentTest

### DIFF
--- a/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
+++ b/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
@@ -30,6 +30,16 @@ public class ClassGenerator {
         this(ClassPool.getDefault());
     }
 
+    /**
+     * This constructor was added specifically to mend an issue in the tests.
+     * The concurrency tests would fail due to a cached object in the {@link ClassPool},
+     * that was fundamentally incompatible with the tests. As such, this
+     * constructor was made to gain control over the instance of the ClassPool
+     * that would be used during testing. Should an issue pop up during testing,
+     * where a baseclass does not contain the fields it should, use this constructor
+     * and pass a new ClassPool.
+     * @param classPool The instance of the ClassPool
+     */
     public ClassGenerator(ClassPool classPool) {
         this.beanMatchStore = new BeanMatchStore(null, null);
         this.classPool = classPool;

--- a/src/test/java/io/beanmapper/dynclass/AbstractConcurrentTest.java
+++ b/src/test/java/io/beanmapper/dynclass/AbstractConcurrentTest.java
@@ -9,13 +9,17 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class AbstractConcurrentTest {
 
-    protected boolean run(int threads, Runnable r) throws InterruptedException {
-        ExecutorService service = Executors.newFixedThreadPool(threads);
-        for (int index = 0; index < threads; index++) {
-            service.submit(r);
+    protected void run(int threads, Runnable r) throws InterruptedException {
+        Thread[] tr = new Thread[threads];
+        for (int t = 0; t < tr.length; t++) {
+            tr[t] = new Thread(r);
         }
-        service.shutdown();
-        return service.awaitTermination(10L, TimeUnit.SECONDS);
+        for (Thread thread : tr) {
+            thread.start();
+        }
+        for (Thread thread : tr) {
+            thread.join();
+        }
     }
 
 }

--- a/src/test/java/io/beanmapper/dynclass/ClassGeneratorTest.java
+++ b/src/test/java/io/beanmapper/dynclass/ClassGeneratorTest.java
@@ -35,7 +35,7 @@ class ClassGeneratorTest extends AbstractConcurrentTest {
             }
         };
 
-        assertTrue(run(8, r));
+        run(8, r);
 
         assertTrue(results.isEmpty(), "%d".formatted(results.size())); // Class generation should produce zero exceptions.
     }

--- a/src/test/java/io/beanmapper/dynclass/ClassStoreTest.java
+++ b/src/test/java/io/beanmapper/dynclass/ClassStoreTest.java
@@ -26,13 +26,13 @@ class ClassStoreTest extends AbstractConcurrentTest {
     @Test
     void shouldCacheThreadSafe() throws InterruptedException {
         final Set<Class> results = new CopyOnWriteArraySet<>();
-        assertTrue(run(8, () -> results.add(store.getOrCreateGeneratedClass(
+        run(8, () -> results.add(store.getOrCreateGeneratedClass(
                 Person.class,
                 Collections.synchronizedList(Collections.singletonList("name")),
                 new BeanMapperBuilder()
                         .build()
                         .getConfiguration()
-                        .getStrictMappingProperties()))));
+                        .getStrictMappingProperties())));
         assertEquals(1, results.size()); // A thread safe implementation should return one class.
     }
 }


### PR DESCRIPTION
- Using an ExecutorService in AbstractConcurrentTest loses too much control and certainty over what thread run which task.
- Added advice on when to use the new constructor in ClassStore