### PR TITLE
Added support for Optional-returning getters (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Issue [#121](https://github.com/42BV/beanmapper/issues/121) **Mapping an Enum field to an Enum field of the same type fails when a custom toString method is 
   present.**; When an Enum with a custom toString-method was mapped to an Enum, the mapping would fail. Fixed by adding an instanceof check in the 
   AnyToEnumConverter, making it use Enum#name() to get the name of an Enum, rather than toString.
+- Issue [#137](https://github.com/42BV/beanmapper/issues/137) **https://github.com/42BV/beanmapper/issues/137**; Mapping a class with a getter that returns an 
+  Optional, would fail, as an Optional can typically not be mapped to the target class. Fixed implementing an OptionalToObjectConverter, which handles unpacking
+  an Optional, and additionally delegates further conversion back to the BeanMapper.
 
 
 ## [3.2.0] - 2022-09-15

--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -2,6 +2,7 @@ package io.beanmapper;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import io.beanmapper.config.BeanMapperBuilder;
@@ -36,6 +37,18 @@ public record BeanMapper(Configuration configuration) {
                 .setTarget(target)
                 .build()
                 .map(source);
+    }
+
+    /**
+     * Copies the values from the optional source object to a newly constructed target instance
+     * @param source optional source instance of the properties
+     * @param targetClass class of the target, needs to be constructed as the target instance
+     * @param <S> the instance from which the properties get copied
+     * @param <T> the instance to which the properties get copied
+     * @return the optional target instance containing all applicable properties
+     */
+    public <S, T> Optional<T> map(Optional<S> source, Class<T> targetClass) {
+        return source.map(value -> this.map(value, targetClass));
     }
 
     /**

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -16,6 +16,7 @@ import io.beanmapper.core.converter.collections.CollectionConverter;
 import io.beanmapper.core.converter.impl.AnyToEnumConverter;
 import io.beanmapper.core.converter.impl.NumberToNumberConverter;
 import io.beanmapper.core.converter.impl.ObjectToStringConverter;
+import io.beanmapper.core.converter.impl.OptionalToObjectConverter;
 import io.beanmapper.core.converter.impl.PrimitiveConverter;
 import io.beanmapper.core.converter.impl.StringToBigDecimalConverter;
 import io.beanmapper.core.converter.impl.StringToBooleanConverter;
@@ -230,6 +231,7 @@ public class BeanMapperBuilder {
         attachConverter(new AnyToEnumConverter());
         attachConverter(new NumberToNumberConverter());
         attachConverter(new ObjectToStringConverter());
+        attachConverter(new OptionalToObjectConverter());
 
         for (CollectionHandler collectionHandler : configuration.getCollectionHandlers()) {
             attachConverter(new CollectionConverter(collectionHandler));

--- a/src/main/java/io/beanmapper/core/converter/impl/OptionalToObjectConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/OptionalToObjectConverter.java
@@ -1,0 +1,31 @@
+package io.beanmapper.core.converter.impl;
+
+import java.util.Optional;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.core.BeanPropertyMatch;
+import io.beanmapper.core.converter.BeanConverter;
+
+public class OptionalToObjectConverter implements BeanConverter {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
+        Object obj = ((Optional<?>) source).orElse(null);
+        if (obj != null && obj.getClass().equals(targetClass)) {
+            return obj;
+        }
+        return beanMapper.map(obj, targetClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean match(Class<?> sourceClass, Class<?> targetClass) {
+        return sourceClass.equals(Optional.class);
+    }
+
+}

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -153,6 +154,8 @@ import io.beanmapper.testmodel.numbers.ClassWithInteger;
 import io.beanmapper.testmodel.numbers.ClassWithLong;
 import io.beanmapper.testmodel.numbers.SourceWithDouble;
 import io.beanmapper.testmodel.numbers.TargetWithDouble;
+import io.beanmapper.testmodel.optional_getter.MyEntity;
+import io.beanmapper.testmodel.optional_getter.MyEntityResult;
 import io.beanmapper.testmodel.othername.SourceWithOtherName;
 import io.beanmapper.testmodel.othername.TargetWithOtherName;
 import io.beanmapper.testmodel.parent.Player;
@@ -1678,6 +1681,69 @@ class BeanMapperTest {
         assertEquals(CountryEnum.NL.getCode(), target.country.code);
         assertEquals(CountryEnum.NL.getDisplayName(), target.country.displayName);
         assertEquals(CountryEnum.NL.getImage(), target.country.image);
+    }
+
+    @Test
+    void testMapClassWithGetterReturningOptionalOfFieldWithStrictMapping() {
+        BeanMapper mapper = new BeanMapperBuilder()
+                .addPackagePrefix("nl")
+                .setApplyStrictMappingConvention(true)
+                .build();
+        MyEntity myEntity = createMyEntity();
+        MyEntityResult result = mapper.map(myEntity, MyEntityResult.class);
+        assertEquals(myEntity.value, result.value);
+        assertEquals(myEntity.child.value, result.child.value);
+    }
+
+    @Test
+    void testMapClassWithGetterReturningOptionalOfFieldWithNonStrictMapping() {
+        BeanMapper mapper = new BeanMapperBuilder()
+                .addPackagePrefix("nl")
+                .setApplyStrictMappingConvention(false)
+                .build();
+        MyEntity myEntity = createMyEntity();
+        MyEntityResult result = mapper.map(myEntity, MyEntityResult.class);
+        assertEquals(myEntity.value, result.value);
+        assertEquals(myEntity.child.value, result.child.value);
+    }
+
+    @Test
+    void testMapClassWithGetterReturningOptionalOfFieldWhereFieldIsNull() {
+        BeanMapper mapper = new BeanMapperBuilder()
+                .addPackagePrefix("nl")
+                .setApplyStrictMappingConvention(false)
+                .build();
+        MyEntity myEntity = createMyEntity();
+        myEntity.child = null;
+        MyEntityResult result = mapper.map(myEntity, MyEntityResult.class);
+        assertEquals("Henk", result.value);
+        assertNull(result.child);
+    }
+
+    @Test
+    void mapToOptional() {
+        Optional<Person> person = Optional.of(createPerson());
+        PersonView personView = beanMapper.map(person, PersonView.class).get();
+        assertEquals("Henk", personView.name);
+        assertEquals("Zoetermeer", personView.place);
+    }
+
+    @Test
+    void mapToOptionalEmpty() {
+        Optional<Person> person = Optional.empty();
+        Optional<PersonView> personView = beanMapper.map(person, PersonView.class);
+        assertFalse(personView.isPresent());
+    }
+
+    private MyEntity createMyEntity() {
+        MyEntity child = new MyEntity();
+        child.value = "Piet";
+
+        MyEntity entity = new MyEntity();
+        entity.child = child;
+        entity.value = "Henk";
+
+        return entity;
     }
 
     public Person createPerson(String name) {

--- a/src/test/java/io/beanmapper/core/converter/impl/OptionalToObjectConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/OptionalToObjectConverterTest.java
@@ -1,0 +1,84 @@
+package io.beanmapper.core.converter.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.testmodel.optional_getter.MyEntity;
+import io.beanmapper.testmodel.optional_getter.MyEntityResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OptionalToObjectConverterTest {
+
+    private OptionalToObjectConverter converter;
+
+    private BeanMapper beanMapper;
+
+    private MyEntity myEntity;
+    private MyEntity child;
+
+    @BeforeEach
+    void setUp() {
+
+        converter = new OptionalToObjectConverter();
+
+        beanMapper = new BeanMapperBuilder().build();
+
+        myEntity = new MyEntity();
+        myEntity.value = "Henk";
+
+        child = new MyEntity();
+        child.value = "Piet";
+
+        myEntity.child = child;
+    }
+
+    @Test
+    void convertEntityWithChild() {
+        var result = this.beanMapper.map(myEntity, MyEntityResult.class);
+        assertEquals(this.myEntity.value, result.value);
+        assertEquals(this.myEntity.child.value, result.child.value);
+        assertNull(result.child.child);
+    }
+
+    @Test
+    void convertEntityWithoutChild() {
+        this.myEntity.child = null;
+        var result = this.beanMapper.map(myEntity, MyEntityResult.class);
+        assertEquals(this.myEntity.value, result.value);
+        assertNull(result.child);
+    }
+
+    @Test
+    void matchIsTrueForSourceOptionalAndObjectTarget() {
+        assertTrue(this.converter.match(Optional.class, Object.class));
+    }
+
+    @Test
+    void matchIsFalseForSourceNotOptional() {
+        assertFalse(this.converter.match(Object.class, Objects.class));
+    }
+
+    @Test
+    void convertEntityWithChildToSameEntity() {
+        var result = this.beanMapper.map(myEntity, MyEntity.class);
+        assertEquals(myEntity.value, result.value);
+        assertEquals(myEntity.child.value, result.child.value);
+        assertEquals(myEntity.child.child, result.child.child);
+    }
+
+    @Test
+    void convertEntityWithoutChildToSameEntity() {
+        this.myEntity.child = null;
+        var result = this.beanMapper.map(myEntity, MyEntity.class);
+        assertEquals(myEntity.value, result.value);
+        assertNull(result.child);
+    }
+
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntity.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntity.java
@@ -1,0 +1,18 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.Optional;
+
+public class MyEntity {
+
+    public String value = "42";
+    public MyEntity child;
+
+    public String getValue() {
+        return value;
+    }
+
+    public Optional<MyEntity> getChild() {
+        return Optional.ofNullable(child);
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResult.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResult.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.optional_getter;
+
+public class MyEntityResult {
+
+    public String value;
+
+    public MyEntityResult child;
+
+}


### PR DESCRIPTION
- Getters returning Optionals can be properly converted to a given target class.
- Added tests to map fields with a getter returning an optional.
- Added the changes made in the map-optional branch to this branch.