### PR TITLE
Implemented fix for issue #121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Issue [#121](https://github.com/42BV/beanmapper/issues/121) **Mapping an Enum field to an Enum field of the same type fails when a custom toString method is 
+  present.**; When an Enum with a custom toString-method was mapped to an Enum, the mapping would fail. Fixed by adding an instanceof check in the 
+  AnyToEnumConverter, making it use Enum#name() to get the name of an Enum, rather than toString.
+
 
 ## [3.2.0] - 2022-09-15
 

--- a/src/main/java/io/beanmapper/core/converter/impl/AnyToEnumConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/AnyToEnumConverter.java
@@ -22,7 +22,7 @@ public class AnyToEnumConverter extends AbstractBeanConverter<Object, Enum<?>> {
         if (source == null) {
             return null;
         }
-        String sourceText = source.toString();
+        String sourceText = source instanceof Enum<?> enumerable ? enumerable.name() : source.toString();
         if (isNotEmpty(sourceText)) {
             return valueOf(targetClass, sourceText);
         }

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -117,11 +117,16 @@ import io.beanmapper.testmodel.encapsulate.source_annotated.Driver;
 import io.beanmapper.testmodel.enums.ColorEntity;
 import io.beanmapper.testmodel.enums.ColorResult;
 import io.beanmapper.testmodel.enums.ColorStringResult;
+import io.beanmapper.testmodel.enums.Day;
+import io.beanmapper.testmodel.enums.DayEnumSourceArraysAsList;
 import io.beanmapper.testmodel.enums.EnumSourceArraysAsList;
 import io.beanmapper.testmodel.enums.EnumTargetList;
 import io.beanmapper.testmodel.enums.RGB;
 import io.beanmapper.testmodel.enums.UserRole;
 import io.beanmapper.testmodel.enums.UserRoleResult;
+import io.beanmapper.testmodel.enums.WeekEntity;
+import io.beanmapper.testmodel.enums.WeekResult;
+import io.beanmapper.testmodel.enums.WeekStringResult;
 import io.beanmapper.testmodel.ignore.IgnoreSource;
 import io.beanmapper.testmodel.ignore.IgnoreTarget;
 import io.beanmapper.testmodel.initially_unmatched_source.SourceWithUnmatchedField;
@@ -221,6 +226,14 @@ class BeanMapperTest {
     }
 
     @Test
+    void mapEnumWithOveriddenToString() {
+        WeekEntity weekEntity = new WeekEntity();
+        weekEntity.setCurrentDay(Day.FRIDAY);
+        WeekResult weekResult = beanMapper.map(weekEntity, WeekResult.class);
+        assertEquals(Day.FRIDAY, weekResult.currentDay);
+    }
+
+    @Test
     void mapEnumWithExistingTarget() throws BeanMappingException {
         ColorEntity source = new ColorEntity();
         source.setCurrentColor(RGB.BLUE);
@@ -233,11 +246,31 @@ class BeanMapperTest {
     }
 
     @Test
+    void mapEnumWithExistingTargetAndOverriddenToString() {
+        WeekEntity weekEntity = new WeekEntity();
+        weekEntity.setCurrentDay(Day.FRIDAY);
+
+        WeekResult weekResult = new WeekResult();
+        weekResult.currentDay = Day.THURSDAY;
+
+        beanMapper.map(weekEntity, weekResult);
+        assertEquals(Day.FRIDAY, weekResult.currentDay);
+    }
+
+    @Test
     void mapEnumToString() throws BeanMappingException {
         ColorEntity colorEntity = new ColorEntity();
         colorEntity.setCurrentColor(RGB.GREEN);
         ColorStringResult colorStringResult = beanMapper.map(colorEntity, ColorStringResult.class);
         assertEquals("GREEN", colorStringResult.currentColor);
+    }
+
+    @Test
+    void mapDayEnumToString() {
+        WeekEntity weekEntity = new WeekEntity();
+        weekEntity.setCurrentDay(Day.FRIDAY);
+        WeekStringResult weekStringResult = beanMapper.map(weekEntity, WeekStringResult.class);
+        assertEquals("Friday", weekStringResult.currentDay);
     }
 
     @Test
@@ -440,6 +473,16 @@ class BeanMapperTest {
         EnumTargetList target = beanMapper.map(source, EnumTargetList.class);
         assertEquals(RGB.values().length, target.items.size());
         assertEquals("RED", target.items.get(0));
+    }
+
+    @Test
+    void mapDayToNestedCollectionArraysAsList() {
+        DayEnumSourceArraysAsList source = new DayEnumSourceArraysAsList();
+        EnumTargetList target = beanMapper.map(source, EnumTargetList.class);
+        assertEquals(Day.values().length, target.items.size());
+        for (var i = 0; i < target.items.size(); i++) {
+            assertEquals(Day.values()[i].toString(), target.items.get(i));
+        }
     }
 
     @Test

--- a/src/test/java/io/beanmapper/testmodel/enums/Day.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/Day.java
@@ -1,0 +1,24 @@
+package io.beanmapper.testmodel.enums;
+
+public enum Day {
+
+    MONDAY("Monday"),
+    TUESDAY("Tuesday"),
+    WEDNESDAY("Wednesday"),
+    THURSDAY("Thursday"),
+    FRIDAY("Friday"),
+    SATURDAY("Saturday"),
+    SUNDAY("Sunday");
+
+    private final String displayName;
+
+    Day(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+        return this.displayName;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/DayEnumSourceArraysAsList.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/DayEnumSourceArraysAsList.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.enums;
+
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class DayEnumSourceArraysAsList {
+
+    @BeanCollection(elementType = String.class)
+    public Object items = List.of(Day.values());
+
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/WeekEntity.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/WeekEntity.java
@@ -1,0 +1,14 @@
+package io.beanmapper.testmodel.enums;
+
+public class WeekEntity {
+
+    private Day currentDay;
+
+    public Day getCurrentDay() {
+        return currentDay;
+    }
+
+    public void setCurrentDay(Day day) {
+        this.currentDay = day;
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/WeekResult.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/WeekResult.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.enums;
+
+public class WeekResult {
+
+    public Day currentDay;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/enums/WeekStringResult.java
+++ b/src/test/java/io/beanmapper/testmodel/enums/WeekStringResult.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.enums;
+
+public class WeekStringResult {
+
+    public String currentDay;
+
+}


### PR DESCRIPTION
- AnyToEnumConverter uses Enum#name() when mapping Enum to Enum.
- Updated tests to include an Enum with an overridden toString-method.