### PR TITLE
Updated dependencies and plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Updated
+
+- Updated Javassist to version 2.29.2-GA, from 2.29.1-GA.
+- Updated SLF4J to version 2.0.3, from 2.0.0.
+- Updated JUnit 5 to version 5.9.0, from 5.8.2.
+- Updated OWASP Dependency Check to version 7.2.0, from 7.1.2.
+- Updated Maven Surefire Plugin to version 3.0.0-M7, from 2.22.2.
+- Updated Maven Release Plugin to version 3.0.0-M6, from 2.5.3.
+
+
 ## [4.0.1] - 2022-09-22
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jackson-databind.version>2.13.4</jackson-databind.version>
-        <javassist.version>3.29.1-GA</javassist.version>
-        <slf4j.version>2.0.0</slf4j.version>
+        <javassist.version>3.29.2-GA</javassist.version>
+        <slf4j.version>2.0.3</slf4j.version>
+        <junit.version>5.9.0</junit.version>
 
-        <junit.version>5.8.2</junit.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
+        <maven.release.plugin.version>3.0.0-M6</maven.release.plugin.version>
+        <nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
+        <jacoco.maven.plugin.version>0.8.8</jacoco.maven.plugin.version>
+        <dependency.check.plugin.version>7.2.1</dependency.check.plugin.version>
+        <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+        <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
     </properties>
 
     <dependencies>
@@ -109,7 +118,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>${maven.compiler.plugin.version}</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
@@ -119,12 +128,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>${maven.surefire.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>${maven.release.plugin.version}</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
@@ -138,7 +147,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <version>${nexus.staging.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>
@@ -149,7 +158,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>${jacoco.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -168,7 +177,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.1.2</version>
+                <version>${dependency.check.plugin.version}</version>
                 <configuration>
                     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <skipProvidedScope>true</skipProvidedScope>
@@ -189,7 +198,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.4.1</version>
+                        <version>${maven.javadoc.plugin.version}</version>
                         <configuration>
                             <source>${java.version}</source>
                         </configuration>
@@ -205,7 +214,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>${maven.source.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -218,7 +227,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>${maven.gpg.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
- Updated Javassist to version 2.29.2-GA, from 2.29.1-GA.
- Updated SLF4J to version 2.0.3, from 2.0.0.
- Updated JUnit 5 to version 5.9.0, from 5.8.2.
- Updated OWASP Dependency Check to version 7.2.0, from 7.1.2.
- Updated Maven Surefire Plugin to version 3.0.0-M7, from 2.22.2.
- Updated Maven Release Plugin to version 3.0.0-M6, from 2.5.3.