### PR TITLE
Methods that return a collection will always return a non-null object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded SLF4J 2.0.0 to 2.0.3
 - Upgraded Javassist 3.29.1-GA to 3.29.2-GA
 
+### Fixed
+
+- Issue [#152](https://github.com/42BV/beanmapper/issues/152) **Methods that return a Collection should never return null.**; All methods that return a
+  Collection, will return an empty Collection of the target type, rather than returning null.
+
 ### Added
 
 - BeanMapper#map(Collection, Class) allowing users to map from a Collection to the type actual type of the 

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -1,6 +1,7 @@
 package io.beanmapper.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import io.beanmapper.BeanMapper;
@@ -121,13 +122,13 @@ public class BeanMapperBuilder {
 
     public BeanMapperBuilder downsizeSource(List<String> includeFields) {
         this.configuration.setApplyStrictMappingConvention(false);
-        this.configuration.downsizeSource(includeFields);
+        this.configuration.downsizeSource(includeFields != null ? includeFields : Collections.emptyList());
         return this;
     }
 
     public BeanMapperBuilder downsizeTarget(List<String> includeFields) {
         this.configuration.setApplyStrictMappingConvention(false);
-        this.configuration.downsizeTarget(includeFields);
+        this.configuration.downsizeTarget(includeFields != null ? includeFields : Collections.emptyList());
         return this;
     }
 

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -1,6 +1,7 @@
 package io.beanmapper.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,10 +101,14 @@ public class CoreConfiguration implements Configuration {
     private Boolean useNullValue = false;
 
     @Override
-    public List<String> getDownsizeTarget() { return null; }
+    public List<String> getDownsizeTarget() {
+        return Collections.emptyList();
+    }
 
     @Override
-    public List<String> getDownsizeSource() { return null; }
+    public List<String> getDownsizeSource() {
+        return Collections.emptyList();
+    }
 
     @Override
     public Class getTargetClass() {
@@ -170,7 +175,7 @@ public class CoreConfiguration implements Configuration {
 
     @Override
     public List<CollectionHandler> getCollectionHandlers() {
-        return collectionHandlerStore.getCollectionHandlers();
+        return this.collectionHandlerStore.getCollectionHandlers();
     }
 
     @Override

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -1,6 +1,7 @@
 package io.beanmapper.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -68,12 +69,14 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public List<String> getDownsizeSource() {
-        return downsizeSourceFields.get();
+        var list = this.downsizeSourceFields.get();
+        return list != null ? list : Collections.emptyList();
     }
 
     @Override
     public List<String> getDownsizeTarget() {
-        return downsizeTargetFields.get();
+        var list =  this.downsizeTargetFields.get();
+        return list != null ? list : Collections.emptyList();
     }
 
     @Override
@@ -128,7 +131,8 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public List<String> getPackagePrefixes() {
-        return parentConfiguration.getPackagePrefixes();
+        var list = parentConfiguration.getPackagePrefixes();
+        return list != null ? list : Collections.emptyList();
     }
 
     @Override
@@ -141,12 +145,14 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public Map<Class<? extends LogicSecuredCheck>, LogicSecuredCheck> getLogicSecuredChecks() {
-        return parentConfiguration.getLogicSecuredChecks();
+        var map = this.parentConfiguration.getLogicSecuredChecks();
+        return map != null ? map : Collections.emptyMap();
     }
 
     @Override
     public List<CollectionHandler> getCollectionHandlers() {
-        return parentConfiguration.getCollectionHandlers();
+        var list = this.parentConfiguration.getCollectionHandlers();
+        return list != null ? list : Collections.emptyList();
     }
 
     @Override
@@ -319,12 +325,12 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void downsizeSource(List<String> includeFields) {
-        this.downsizeSourceFields.set(includeFields);
+        this.downsizeSourceFields.set(includeFields != null ? includeFields : Collections.emptyList());
     }
 
     @Override
     public void downsizeTarget(List<String> includeFields) {
-        this.downsizeTargetFields.set(includeFields);
+        this.downsizeTargetFields.set(includeFields != null ? includeFields : Collections.emptyList());
     }
 
     @Override

--- a/src/main/java/io/beanmapper/core/BeanMatch.java
+++ b/src/main/java/io/beanmapper/core/BeanMatch.java
@@ -1,6 +1,7 @@
 package io.beanmapper.core;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -21,9 +22,9 @@ public class BeanMatch {
 
     public BeanMatch(BeanPair beanPair, Map<String, BeanProperty> sourceNodes, Map<String, BeanProperty> targetNodes, Map<String, BeanProperty> aliases) {
         this.beanPair = beanPair;
-        this.sourceNodes = sourceNodes;
-        this.targetNodes = targetNodes;
-        this.aliases = aliases;
+        this.sourceNodes = sourceNodes != null ? sourceNodes : Collections.emptyMap();
+        this.targetNodes = targetNodes != null ? targetNodes : Collections.emptyMap();
+        this.aliases = aliases != null ? aliases : Collections.emptyMap();
         validateMappingRequirements();
     }
 
@@ -36,15 +37,15 @@ public class BeanMatch {
     }
 
     public Map<String, BeanProperty> getSourceNodes() {
-        return sourceNodes;
+        return this.sourceNodes != null ? this.sourceNodes : Collections.emptyMap();
     }
 
     public Map<String, BeanProperty> getTargetNodes() {
-        return targetNodes;
+        return this.targetNodes != null ? this.targetNodes : Collections.emptyMap();
     }
 
     public Map<String, BeanProperty> getAliases() {
-        return aliases;
+        return this.aliases != null ? this.aliases : Collections.emptyMap();
     }
 
     public MatchedBeanPropertyPair findBeanPairField(String fieldName) {
@@ -77,9 +78,9 @@ public class BeanMatch {
         }
     }
 
-    private List<BeanProperty> validateMappingRequirements(Map<String, BeanProperty> fields) {
+    private List<BeanProperty> validateMappingRequirements(Map<String, BeanProperty> nodes) {
         List<BeanProperty> missingMatches = new ArrayList<>();
-        for (String fieldName : fields.keySet()) {
+        for (String fieldName : nodes.keySet()) {
             MatchedBeanPropertyPair matchedField = findBeanPairField(fieldName);
             BeanProperty sourceBeanProperty = matchedField.sourceBeanProperty();
             BeanProperty targetBeanProperty = matchedField.targetBeanProperty();

--- a/src/main/java/io/beanmapper/core/BeanMatchValidationMessage.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchValidationMessage.java
@@ -1,5 +1,6 @@
 package io.beanmapper.core;
 
+import java.util.Collections;
 import java.util.List;
 
 import io.beanmapper.config.BeanPair;
@@ -18,7 +19,7 @@ public class BeanMatchValidationMessage {
     }
 
     public List<BeanProperty> getFields() {
-        return fields;
+        return this.fields != null ? this.fields : Collections.emptyList();
     }
 
     public Class<?> getSourceClass() {

--- a/src/main/java/io/beanmapper/core/BeanStrictMappingRequirementsException.java
+++ b/src/main/java/io/beanmapper/core/BeanStrictMappingRequirementsException.java
@@ -46,7 +46,7 @@ public class BeanStrictMappingRequirementsException extends RuntimeException {
     }
 
     public List<BeanMatchValidationMessage> getValidationMessages() {
-        return validationMessages;
+        return this.validationMessages != null ? this.validationMessages : Collections.emptyList();
     }
 
 }

--- a/src/main/java/io/beanmapper/strategy/MapStrategyType.java
+++ b/src/main/java/io/beanmapper/strategy/MapStrategyType.java
@@ -35,7 +35,7 @@ public enum MapStrategyType {
     }
 
     public static MapStrategyType determineStrategy(Configuration configuration) {
-        if (configuration.getDownsizeSource() != null || configuration.getDownsizeTarget() != null) {
+        if (!configuration.getDownsizeSource().isEmpty() || !configuration.getDownsizeTarget().isEmpty()) {
             return CREATE_DYNAMIC_CLASS;
         } else if (configuration.getCollectionClass() != null) {
             return MAP_COLLECTION;

--- a/src/test/java/io/beanmapper/config/CoreConfigurationTest.java
+++ b/src/test/java/io/beanmapper/config/CoreConfigurationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.beanmapper.exceptions.BeanConfigurationOperationNotAllowedException;
 
@@ -50,8 +51,8 @@ class CoreConfigurationTest {
     @Test
     void singleMapRunProperties() {
         CoreConfiguration configuration = new CoreConfiguration();
-        assertNull(configuration.getDownsizeSource());
-        assertNull(configuration.getDownsizeTarget());
+        assertTrue(configuration.getDownsizeSource().isEmpty());
+        assertTrue(configuration.getDownsizeTarget().isEmpty());
         assertNull(configuration.getTargetClass());
         assertNull(configuration.getTarget());
         assertNull(configuration.getParent());


### PR DESCRIPTION
- Every method that returns a collection that may be null, will check whether the collection is null. If the collection is null, the method will return an empty, immutable collection of the correct type.
- Updated relevant tests to reflect that methods returning a collection will never return null when a collection is required.