### PR TITLE
Replaced usages of Boolean-class, with primitive or enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for mapping Queue. A Queue will be mapped to an ArrayDeque by default. The order of elements is guaranteed to be preserved, except when the Queue is 
   mapped to a Queue that inherently modifies the order of elements (e.g. PriorityQueue).
 
+### Fixed
+
+- Issue [#153](https://github.com/42BV/beanmapper/issues/153) **https://github.com/42BV/beanmapper/issues/153**; Rather than using the Boolean-wrapper, all 
+  occurrences of Boolean that are not absolutely necessary due to generics, have been replaced with the primitive boolean, or the 
+  FlushAfterClearInstruction-enum.
+
 
 ## [4.0.1] - 2022-09-22
 

--- a/src/main/java/io/beanmapper/annotations/BeanCollection.java
+++ b/src/main/java/io/beanmapper/annotations/BeanCollection.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.beanmapper.config.FlushAfterClearInstruction;
+
 /**
  * Determines the type of the other side in a collection. When this annotation is set, beanmapper
  * logic is activated on it.
@@ -53,6 +55,6 @@ public @interface BeanCollection {
      * original state being preserved.
      * @return Whether to flush the collection after clearing or not.
      */
-    boolean flushAfterClear() default true;
+    FlushAfterClearInstruction flushAfterClear() default FlushAfterClearInstruction.FLUSH_ENABLED;
 
 }

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -105,7 +105,7 @@ public class BeanMapperBuilder {
         return this;
     }
 
-    public BeanMapperBuilder setEnforcedSecuredProperties(Boolean enforcedSecuredProperties) {
+    public BeanMapperBuilder setEnforcedSecuredProperties(boolean enforcedSecuredProperties) {
         this.configuration.setEnforceSecuredProperties(enforcedSecuredProperties);
         return this;
     }
@@ -166,8 +166,8 @@ public class BeanMapperBuilder {
         this.configuration.setStrictTargetSuffix(strictTargetSuffix);
         return this;
     }
-
-    public BeanMapperBuilder setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+    
+    public BeanMapperBuilder setApplyStrictMappingConvention(boolean applyStrictMappingConvention) {
         this.configuration.setApplyStrictMappingConvention(applyStrictMappingConvention);
         return this;
     }
@@ -182,7 +182,7 @@ public class BeanMapperBuilder {
         return this;
     }
 
-    public BeanMapperBuilder setFlushAfterClear(boolean flushAfterClear) {
+    public BeanMapperBuilder setFlushAfterClear(FlushAfterClearInstruction flushAfterClear) {
         this.configuration.setFlushAfterClear(flushAfterClear);
         return this;
     }

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -113,7 +113,7 @@ public interface Configuration {
      */
     List<BeanPair> getBeanPairs();
 
-    Boolean isConverterChoosable();
+    boolean isConverterChoosable();
 
     void withoutDefaultConverters();
 
@@ -138,7 +138,7 @@ public interface Configuration {
      * properties will require matching properties on the other side. Default is true.
      * @return if true, the strict mapping convention will be applied
      */
-    Boolean isApplyStrictMappingConvention();
+    boolean isApplyStrictMappingConvention();
 
     /**
      * Returns the collection of strictSourceSuffix, strictTargetSuffix and
@@ -173,7 +173,7 @@ public interface Configuration {
      * collection has taken place.
      * @return true if the flush-chain must be called after a clear
      */
-    Boolean isFlushAfterClear();
+    FlushAfterClearInstruction isFlushAfterClear();
 
     /**
      * Determines if flushing has been enabled. Flushing is the calling of flush() on a collection
@@ -182,20 +182,20 @@ public interface Configuration {
      * case, the flush will throw an exception.
      * @return whether flushing has been enabled
      */
-    Boolean isFlushEnabled();
+    boolean isFlushEnabled();
 
     /**
      * Works on the combination of the global flush setting (flushEnabled) and the specific flush
      * setting (flushAfterClear). If both are true, the flush will trigger.
      * @return true if a flush after clear must take place
      */
-    Boolean mustFlush();
+    boolean mustFlush();
 
     /**
      * Property that determines if null values for the source must be skipped or not
      * @return determines if null values must be skipped or not
      */
-    Boolean getUseNullValue();
+    boolean getUseNullValue();
 
     /**
      * The RoleSecuredCheck is responsible for checking if a Principal may access
@@ -210,7 +210,7 @@ public interface Configuration {
      * and the RoleSecuredCheck has not been set, an exception will be thrown.
      * @return whether the handling of secured properties is enforced
      */
-    Boolean getEnforceSecuredProperties();
+    boolean getEnforceSecuredProperties();
 
     /**
      * Add a converter class (must inherit from abstract BeanConverter class) to the beanMapper.
@@ -369,7 +369,7 @@ public interface Configuration {
      * properties will require matching properties on the other side. Default is true.
      * @param applyStrictMappingConvention whether the strict mapping convention must be applied
      */
-    void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention);
+    void setApplyStrictMappingConvention(boolean applyStrictMappingConvention);
 
     /**
      * Sets the collection usage for the current collection mapping
@@ -388,7 +388,7 @@ public interface Configuration {
      * Determines whether the flush-chain must be called after a clear has taken place.
      * @param flushAfterClear true if the flush-chain must be called
      */
-    void setFlushAfterClear(Boolean flushAfterClear);
+    void setFlushAfterClear(FlushAfterClearInstruction flushAfterClear);
 
     /**
      * Set whether flushing must be enabled. Flushing is the calling of flush() on a collection
@@ -397,7 +397,7 @@ public interface Configuration {
      * case, the flush will throw an exception.
      * @param flushEnabled whether flushing has been enabled
      */
-    void setFlushEnabled(Boolean flushEnabled);
+    void setFlushEnabled(boolean flushEnabled);
 
     /**
      * The RoleSecuredCheck is responsible for checking if a Principal may access
@@ -411,12 +411,12 @@ public interface Configuration {
      * and the RoleSecuredCheck has not been set, an exception will be thrown.
      * @param enforceSecuredProperties whether the handling of secured properties is enforced
      */
-    void setEnforceSecuredProperties(Boolean enforceSecuredProperties);
+    void setEnforceSecuredProperties(boolean enforceSecuredProperties);
 
     /**
      * Property that determines if null values for the source must be skipped or not
      * @param useNullValue determines if null values must be skipped or not
      */
-    void setUseNullValue(Boolean useNullValue);
+    void setUseNullValue(boolean useNullValue);
 
 }

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -72,7 +72,7 @@ public class CoreConfiguration implements Configuration {
     /**
      * The value that decides whether a converter may be chosen, or direct mapping has to take place
      */
-    private Boolean converterChoosable;
+    private boolean converterChoosable;
 
     private boolean addDefaultConverters = true;
 
@@ -80,7 +80,7 @@ public class CoreConfiguration implements Configuration {
 
     private CollectionFlusher collectionFlusher = new CollectionFlusher();
 
-    private Boolean flushEnabled = false;
+    private boolean flushEnabled;
 
     /**
      * The RoleSecuredCheck is responsible for checking if a Principal may access
@@ -92,13 +92,13 @@ public class CoreConfiguration implements Configuration {
      * Property that determines if secured properties must be handled. If this is set to true
      * and the RoleSecuredCheck has not been set, an exception will be thrown.
      */
-    private Boolean enforceSecuredProperties = true;
+    private boolean enforceSecuredProperties = true;
 
     /**
      * Property that determines if null values for the source will be used. Normal behaviour
      * is to skip the mapping operation if a source value is null.
      */
-    private Boolean useNullValue = false;
+    private boolean useNullValue;
 
     @Override
     public List<String> getDownsizeTarget() {
@@ -184,8 +184,8 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean isConverterChoosable() {
-        return converterChoosable != null && converterChoosable;
+    public boolean isConverterChoosable() {
+        return converterChoosable;
     }
 
     @Override
@@ -204,7 +204,7 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean isApplyStrictMappingConvention() {
+    public boolean isApplyStrictMappingConvention() {
         return strictMappingProperties.isApplyStrictMappingConvention();
     }
 
@@ -230,22 +230,22 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean isFlushAfterClear() {
-        return false;
+    public FlushAfterClearInstruction isFlushAfterClear() {
+        return FlushAfterClearInstruction.FLUSH_DISABLED;
     }
 
     @Override
-    public Boolean isFlushEnabled() {
+    public boolean isFlushEnabled() {
         return this.flushEnabled;
     }
 
     @Override
-    public Boolean mustFlush() {
+    public boolean mustFlush() {
         return false;
     }
 
     @Override
-    public Boolean getUseNullValue() {
+    public boolean getUseNullValue() {
         return this.useNullValue;
     }
 
@@ -255,7 +255,7 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean getEnforceSecuredProperties() {
+    public boolean getEnforceSecuredProperties() {
         return enforceSecuredProperties;
     }
 
@@ -377,7 +377,7 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+    public void setApplyStrictMappingConvention(boolean applyStrictMappingConvention) {
         this.strictMappingProperties.setApplyStrictMappingConvention(applyStrictMappingConvention);
     }
 
@@ -394,13 +394,13 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public void setFlushAfterClear(Boolean flushAfterClear) {
+    public void setFlushAfterClear(FlushAfterClearInstruction flushAfterClear) {
         throw new BeanConfigurationOperationNotAllowedException(
                 "Illegal to set flush after clear on the core configuration");
     }
 
     @Override
-    public void setFlushEnabled(Boolean flushEnabled) {
+    public void setFlushEnabled(boolean flushEnabled) {
         this.flushEnabled = flushEnabled;
     }
 
@@ -410,12 +410,12 @@ public class CoreConfiguration implements Configuration {
     }
 
     @Override
-    public void setEnforceSecuredProperties(Boolean enforceSecuredProperties) {
+    public void setEnforceSecuredProperties(boolean enforceSecuredProperties) {
         this.enforceSecuredProperties = enforceSecuredProperties;
     }
 
     @Override
-    public void setUseNullValue(Boolean useNullValue) {
+    public void setUseNullValue(boolean useNullValue) {
         this.useNullValue = useNullValue;
     }
 

--- a/src/main/java/io/beanmapper/config/FlushAfterClearInstruction.java
+++ b/src/main/java/io/beanmapper/config/FlushAfterClearInstruction.java
@@ -1,0 +1,7 @@
+package io.beanmapper.config;
+
+public enum FlushAfterClearInstruction {
+
+    FLUSH_ENABLED, FLUSH_DISABLED, UNSET
+
+}

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -38,17 +38,17 @@ public class OverrideConfiguration implements Configuration {
 
     private OverrideField<Boolean> converterChoosable;
 
-    private StrictMappingProperties strictMappingProperties = StrictMappingProperties.emptyConfig();
+    private OverrideField<StrictMappingProperties> strictMappingProperties;
 
     private BeanCollectionUsage collectionUsage = null;
 
     private Class<?> preferredCollectionClass = null;
 
-    private Boolean enforcedSecuredProperties = null;
+    private OverrideField<Boolean> enforcedSecuredProperties;
 
     private OverrideField<Boolean> useNullValue;
 
-    private OverrideField<Boolean> flushAfterClear;
+    private OverrideField<FlushAfterClearInstruction> flushAfterClear;
 
     private OverrideField<Boolean> flushEnabled;
 
@@ -65,6 +65,8 @@ public class OverrideConfiguration implements Configuration {
         this.flushAfterClear = new OverrideField<>(configuration::isFlushAfterClear);
         this.flushEnabled = new OverrideField<>(configuration::isFlushEnabled);
         this.useNullValue = new OverrideField<>(configuration::getUseNullValue);
+        this.strictMappingProperties = new OverrideField<>(configuration::getStrictMappingProperties);
+        this.enforcedSecuredProperties = new OverrideField<>(configuration::getEnforceSecuredProperties);
     }
 
     @Override
@@ -164,7 +166,7 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean isConverterChoosable() {
+    public boolean isConverterChoosable() {
         return converterChoosable.get();
     }
 
@@ -175,23 +177,17 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public String getStrictSourceSuffix() {
-        return strictMappingProperties.getStrictSourceSuffix() == null ?
-                parentConfiguration.getStrictSourceSuffix() :
-                strictMappingProperties.getStrictSourceSuffix();
+        return this.strictMappingProperties.get().getStrictSourceSuffix();
     }
 
     @Override
     public String getStrictTargetSuffix() {
-        return strictMappingProperties.getStrictTargetSuffix() == null ?
-                parentConfiguration.getStrictTargetSuffix() :
-                strictMappingProperties.getStrictTargetSuffix();
+        return strictMappingProperties.get().getStrictTargetSuffix();
     }
 
     @Override
-    public Boolean isApplyStrictMappingConvention() {
-        return strictMappingProperties.isApplyStrictMappingConvention() == null ?
-                parentConfiguration.isApplyStrictMappingConvention() :
-                strictMappingProperties.isApplyStrictMappingConvention();
+    public boolean isApplyStrictMappingConvention() {
+        return strictMappingProperties.get().isApplyStrictMappingConvention();
     }
 
     @Override
@@ -222,22 +218,22 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean isFlushAfterClear() {
+    public FlushAfterClearInstruction isFlushAfterClear() {
         return flushAfterClear.get();
     }
 
     @Override
-    public Boolean isFlushEnabled() {
-        return flushEnabled.get();
+    public boolean isFlushEnabled() {
+        return this.flushEnabled.get();
     }
 
     @Override
-    public Boolean mustFlush() {
-        return isFlushEnabled() && isFlushAfterClear();
+    public boolean mustFlush() {
+        return isFlushEnabled() && isFlushAfterClear() == FlushAfterClearInstruction.FLUSH_ENABLED;
     }
 
     @Override
-    public Boolean getUseNullValue() {
+    public boolean getUseNullValue() {
         return useNullValue.get();
     }
 
@@ -247,10 +243,8 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
-    public Boolean getEnforceSecuredProperties() {
-        return this.enforcedSecuredProperties == null ?
-                parentConfiguration.getEnforceSecuredProperties() :
-                this.enforcedSecuredProperties;
+    public boolean getEnforceSecuredProperties() {
+        return this.enforcedSecuredProperties.get();
     }
 
     @Override
@@ -304,8 +298,8 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
-    public void setEnforceSecuredProperties(Boolean enforceSecuredProperties) {
-        this.enforcedSecuredProperties = enforceSecuredProperties;
+    public void setEnforceSecuredProperties(boolean enforceSecuredProperties) {
+        this.enforcedSecuredProperties.set(enforceSecuredProperties);
     }
 
     @Override
@@ -365,17 +359,17 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void setStrictSourceSuffix(String strictSourceSuffix) {
-        this.strictMappingProperties.setStrictSourceSuffix(strictSourceSuffix);
+        this.strictMappingProperties.get().setStrictSourceSuffix(strictSourceSuffix);
     }
 
     @Override
     public void setStrictTargetSuffix(String strictTargetSuffix) {
-        this.strictMappingProperties.setStrictTargetSuffix(strictTargetSuffix);
+        this.strictMappingProperties.get().setStrictTargetSuffix(strictTargetSuffix);
     }
 
     @Override
-    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
-        this.strictMappingProperties.setApplyStrictMappingConvention(applyStrictMappingConvention);
+    public void setApplyStrictMappingConvention(boolean applyStrictMappingConvention) {
+        this.strictMappingProperties.get().setApplyStrictMappingConvention(applyStrictMappingConvention);
     }
 
     @Override
@@ -389,17 +383,17 @@ public class OverrideConfiguration implements Configuration {
     }
 
     @Override
-    public void setFlushAfterClear(Boolean flushAfterClear) {
+    public void setFlushAfterClear(FlushAfterClearInstruction flushAfterClear) {
         this.flushAfterClear.set(flushAfterClear);
     }
 
     @Override
-    public void setFlushEnabled(Boolean flushEnabled) {
+    public void setFlushEnabled(boolean flushEnabled) {
         this.flushEnabled.set(flushEnabled);
     }
 
     @Override
-    public void setUseNullValue(Boolean useNullValue) {
+    public void setUseNullValue(boolean useNullValue) {
         this.useNullValue.set(useNullValue);
     }
 

--- a/src/main/java/io/beanmapper/config/StrictMappingProperties.java
+++ b/src/main/java/io/beanmapper/config/StrictMappingProperties.java
@@ -25,13 +25,13 @@ public class StrictMappingProperties {
      * the classes will be treated as if they are strict. This implies that all of their
      * properties will require matching properties on the other side.
      */
-    private Boolean applyStrictMappingConvention;
+    private boolean applyStrictMappingConvention;
 
     public StrictMappingProperties(
             BeanUnproxy beanUnproxy,
             String strictSourceSuffix,
             String strictTargetSuffix,
-            Boolean applyStrictMappingConvention) {
+            boolean applyStrictMappingConvention) {
         this.beanUnproxy = beanUnproxy;
         this.strictSourceSuffix = strictSourceSuffix;
         this.strictTargetSuffix = strictTargetSuffix;
@@ -46,7 +46,7 @@ public class StrictMappingProperties {
         return strictTargetSuffix;
     }
 
-    public Boolean isApplyStrictMappingConvention() {
+    public boolean isApplyStrictMappingConvention() {
         return applyStrictMappingConvention;
     }
 
@@ -58,7 +58,7 @@ public class StrictMappingProperties {
         this.strictTargetSuffix = strictTargetSuffix;
     }
 
-    public void setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
+    public void setApplyStrictMappingConvention(boolean applyStrictMappingConvention) {
         this.applyStrictMappingConvention = applyStrictMappingConvention;
     }
 
@@ -93,7 +93,7 @@ public class StrictMappingProperties {
                 null,
                 null,
                 null,
-                null);
+                false);
     }
 
     public void setBeanUnproxy(SkippingBeanUnproxy beanUnproxy) {

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -19,6 +19,7 @@ import io.beanmapper.annotations.BeanRoleSecured;
 import io.beanmapper.annotations.BeanUnwrap;
 import io.beanmapper.config.BeanPair;
 import io.beanmapper.config.CollectionHandlerStore;
+import io.beanmapper.config.FlushAfterClearInstruction;
 import io.beanmapper.core.collections.CollectionHandler;
 import io.beanmapper.core.converter.collections.AnnotationClass;
 import io.beanmapper.core.converter.collections.BeanCollectionInstructions;
@@ -208,7 +209,7 @@ public class BeanMatchStore {
         CollectionElementType elementType = EMPTY_COLLECTION_ELEMENT_TYPE;
         BeanCollectionUsage beanCollectionUsage = null;
         AnnotationClass preferredCollectionClass = EMPTY_ANNOTATION_CLASS;
-        Boolean flushAfterClear = null;
+        FlushAfterClearInstruction flushAfterClear = FlushAfterClearInstruction.UNSET;
 
         CollectionHandler collectionHandler = null;
         if (beanCollection == null) {

--- a/src/main/java/io/beanmapper/core/BeanPropertyMatch.java
+++ b/src/main/java/io/beanmapper/core/BeanPropertyMatch.java
@@ -42,7 +42,7 @@ public class BeanPropertyMatch {
     public boolean hasAccess(
             RoleSecuredCheck roleSecuredCheck,
             Map<Class<? extends LogicSecuredCheck>, LogicSecuredCheck> logicSecuredChecks,
-            Boolean enforcedSecuredProperties) {
+            boolean enforcedSecuredProperties) {
 
         boolean accessAllowed = checkForLogicSecured(
                 logicSecuredChecks, sourceBeanProperty, source, target, enforcedSecuredProperties);
@@ -52,7 +52,7 @@ public class BeanPropertyMatch {
         return accessAllowed && checkForRoleSecured(roleSecuredCheck, enforcedSecuredProperties);
     }
 
-    private boolean checkForRoleSecured(RoleSecuredCheck roleSecuredCheck, Boolean enforcedSecuredProperties) {
+    private boolean checkForRoleSecured(RoleSecuredCheck roleSecuredCheck, boolean enforcedSecuredProperties) {
         if (roleSecuredCheck == null) {
             checkIfSecuredFieldHandlerNotSet(sourceBeanProperty, enforcedSecuredProperties);
             checkIfSecuredFieldHandlerNotSet(targetBeanProperty, enforcedSecuredProperties);

--- a/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
@@ -49,7 +49,7 @@ public abstract class AbstractCollectionHandler<C> implements CollectionHandler<
             Class<?> collectionElementClass,
             C targetCollection,
             CollectionFlusher collectionFlusher,
-            Boolean mustFlush) {
+            boolean mustFlush) {
 
         C useTargetCollection = collectionUsage.mustConstruct(targetCollection) ?
                 createCollection(preferredCollectionClass, collectionElementClass) :

--- a/src/main/java/io/beanmapper/core/collections/CollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/CollectionHandler.java
@@ -45,7 +45,7 @@ public interface CollectionHandler<C> {
             Class<?> collectionElementClass,
             C targetCollection,
             CollectionFlusher collectionFlusher,
-            Boolean flushAfterClear);
+            boolean flushAfterClear);
 
     /**
      * The type of the collection class. This will be used to determine if the source

--- a/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/BeanCollectionInstructions.java
@@ -3,6 +3,7 @@ package io.beanmapper.core.converter.collections;
 import static io.beanmapper.core.converter.collections.AnnotationClass.EMPTY_ANNOTATION_CLASS;
 
 import io.beanmapper.annotations.BeanCollectionUsage;
+import io.beanmapper.config.FlushAfterClearInstruction;
 import io.beanmapper.core.BeanProperty;
 
 public class BeanCollectionInstructions {
@@ -13,7 +14,7 @@ public class BeanCollectionInstructions {
 
     private AnnotationClass preferredCollectionClass = EMPTY_ANNOTATION_CLASS;
 
-    private Boolean flushAfterClear;
+    private FlushAfterClearInstruction flushAfterClear;
 
     public CollectionElementType getCollectionElementType() {
         return collectionElementType;
@@ -39,12 +40,12 @@ public class BeanCollectionInstructions {
         this.preferredCollectionClass = preferredCollectionClass;
     }
 
-    public Boolean getFlushAfterClear() {
+    public FlushAfterClearInstruction getFlushAfterClear() {
         return flushAfterClear;
     }
 
-    public void setFlushAfterClear(Boolean flushAfterClear) {
-        this.flushAfterClear = flushAfterClear;
+    public void setFlushAfterClear(FlushAfterClearInstruction flushAfterClear) {
+        this.flushAfterClear = flushAfterClear != FlushAfterClearInstruction.UNSET ? flushAfterClear : FlushAfterClearInstruction.FLUSH_ENABLED;
     }
 
     public static BeanCollectionInstructions merge(
@@ -71,10 +72,7 @@ public class BeanCollectionInstructions {
             BeanCollectionInstructions target,
             BeanCollectionInstructions source) {
         BeanCollectionInstructions merged = new BeanCollectionInstructions();
-        merged.setFlushAfterClear(chooseValue(
-                target.getFlushAfterClear(),
-                source == null ? null : source.getFlushAfterClear(),
-                true));
+        merged.setFlushAfterClear(target.getFlushAfterClear());
         merged.setBeanCollectionUsage(chooseValue(
                 target.getBeanCollectionUsage(),
                 source == null ? null : source.getBeanCollectionUsage(),

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -26,7 +26,7 @@ public class CollectionConverter<T> implements BeanConverter {
             return sourceCollection;
         }
 
-        return (T)beanMapper.wrap()
+        return (T) beanMapper.wrap()
                 .setCollectionClass(collectionHandler.getType())
                 .setCollectionUsage(beanPropertyMatch.getCollectionInstructions().getBeanCollectionUsage())
                 .setPreferredCollectionClass(beanPropertyMatch.getCollectionInstructions().getPreferredCollectionClass().getAnnotationClass())

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import io.beanmapper.annotations.BeanCollectionUsage;
 import io.beanmapper.config.AfterClearFlusher;
 import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.config.FlushAfterClearInstruction;
 import io.beanmapper.config.RoleSecuredCheck;
 import io.beanmapper.core.BeanStrictMappingRequirementsException;
 import io.beanmapper.core.converter.impl.LocalDateTimeToLocalDate;
@@ -1362,7 +1363,10 @@ class BeanMapperTest {
     void beanCollectionClearCallsAfterClearFlusher() throws Exception {
         AfterClearFlusher afterClearFlusher = createAfterClearFlusher();
         BeanMapper beanMapper = new BeanMapperBuilder()
+                .addAfterClearFlusher(afterClearFlusher)
+                .build().wrap()
                 .setFlushEnabled(true)
+                .setFlushAfterClear(FlushAfterClearInstruction.FLUSH_ENABLED)
                 .addAfterClearFlusher(afterClearFlusher)
                 .build();
         CollSourceClearFlush source = new CollSourceClearFlush() {{
@@ -1393,6 +1397,7 @@ class BeanMapperTest {
         beanMapper.map(source, target);
         assertFalse(afterClearFlusher.getClass().getField("trigger").getBoolean(afterClearFlusher),
                 "Should NOT have called the afterClearFlusher instance");
+        var wait = true;
     }
 
     private AfterClearFlusher createAfterClearFlusher() {
@@ -1805,7 +1810,7 @@ class BeanMapperTest {
                 .setPreferredCollectionClass(PriorityQueue.class)
                 .setCollectionUsage(BeanCollectionUsage.CONSTRUCT)
                 .setTargetClass(Long.class)
-                .setFlushAfterClear(false)
+                .setFlushAfterClear(FlushAfterClearInstruction.FLUSH_DISABLED)
                 .build()
                 .map(collection, Long.class);
 

--- a/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
+++ b/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
@@ -50,7 +50,7 @@ class BeanMapperBuilderTest {
     void setFlushAfterClear() {
         assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> {
             BeanMapperBuilder builder = new BeanMapperBuilder();
-            builder.setFlushAfterClear(true);
+            builder.setFlushAfterClear(FlushAfterClearInstruction.FLUSH_ENABLED);
         });
     }
 

--- a/src/test/java/io/beanmapper/config/CoreConfigurationTest.java
+++ b/src/test/java/io/beanmapper/config/CoreConfigurationTest.java
@@ -59,7 +59,7 @@ class CoreConfigurationTest {
         assertNull(configuration.getCollectionClass());
         assertNull(configuration.getPreferredCollectionClass());
         assertNull(configuration.getCollectionHandlerForCollectionClass());
-        assertFalse(configuration.isFlushAfterClear());
+        assertEquals(FlushAfterClearInstruction.FLUSH_DISABLED, configuration.isFlushAfterClear());
         assertFalse(configuration.mustFlush());
     }
 

--- a/src/test/java/io/beanmapper/config/OverrideConfigurationTest.java
+++ b/src/test/java/io/beanmapper/config/OverrideConfigurationTest.java
@@ -46,17 +46,17 @@ public class OverrideConfigurationTest {
     @Test
     void mustFlush() {
         overrideConfiguration.setFlushEnabled(true);
-        overrideConfiguration.setFlushAfterClear(true);
-        assertEquals(true, overrideConfiguration.isFlushEnabled());
-        assertEquals(true, overrideConfiguration.isFlushAfterClear());
-        assertEquals(true, overrideConfiguration.mustFlush());
+        overrideConfiguration.setFlushAfterClear(FlushAfterClearInstruction.FLUSH_ENABLED);
+        assertTrue(overrideConfiguration.isFlushEnabled());
+        assertEquals(FlushAfterClearInstruction.FLUSH_ENABLED, overrideConfiguration.isFlushAfterClear());
+        assertTrue(overrideConfiguration.mustFlush());
     }
 
     @Test
     void mustFlush_flushAfterClearIsFalse() {
         overrideConfiguration.setFlushEnabled(true);
-        overrideConfiguration.setFlushAfterClear(false);
-        assertEquals(false, overrideConfiguration.mustFlush());
+        overrideConfiguration.setFlushAfterClear(FlushAfterClearInstruction.FLUSH_DISABLED);
+        assertFalse(overrideConfiguration.mustFlush());
     }
 
     @Test

--- a/src/test/java/io/beanmapper/core/converter/collections/BeanCollectionInstructionsTest.java
+++ b/src/test/java/io/beanmapper/core/converter/collections/BeanCollectionInstructionsTest.java
@@ -1,7 +1,7 @@
 package io.beanmapper.core.converter.collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.beanmapper.annotations.BeanCollectionUsage;
+import io.beanmapper.config.FlushAfterClearInstruction;
 import io.beanmapper.core.BeanProperty;
 import io.beanmapper.core.BeanPropertyCreator;
 import io.beanmapper.core.BeanPropertyMatchupDirection;
@@ -39,14 +40,15 @@ class BeanCollectionInstructionsTest {
                 CollectionElementType.derived(String.class),
                 null,
                 null,
-                null));
+                FlushAfterClearInstruction.FLUSH_ENABLED));
 
         BeanCollectionInstructions merged = BeanCollectionInstructions.merge(sourceBeanProperty, targetBeanProperty);
 
+        assertNotNull(merged);
         assertEquals(String.class, merged.getCollectionElementType().getType());
         assertEquals(BeanCollectionUsage.CLEAR, merged.getBeanCollectionUsage());
         assertTrue(merged.getPreferredCollectionClass().isEmpty());
-        assertTrue(merged.getFlushAfterClear());
+        assertEquals(FlushAfterClearInstruction.FLUSH_ENABLED, merged.getFlushAfterClear());
     }
 
     @Test
@@ -66,20 +68,21 @@ class BeanCollectionInstructionsTest {
                 CollectionElementType.set(Long.class),
                 BeanCollectionUsage.REUSE,
                 new AnnotationClass(ArrayList.class),
-                false));
+                FlushAfterClearInstruction.FLUSH_DISABLED));
 
         targetBeanProperty.setCollectionInstructions(createBeanCollectionInstructions(
                 CollectionElementType.derived(String.class),
                 null,
                 null,
-                null));
+                FlushAfterClearInstruction.FLUSH_DISABLED));
 
         BeanCollectionInstructions merged = BeanCollectionInstructions.merge(sourceBeanProperty, targetBeanProperty);
 
+        assertNotNull(merged);
         assertEquals(Long.class, merged.getCollectionElementType().getType());
         assertEquals(BeanCollectionUsage.REUSE, merged.getBeanCollectionUsage());
         assertEquals(ArrayList.class, merged.getPreferredCollectionClass().getAnnotationClass());
-        assertFalse(merged.getFlushAfterClear());
+        assertEquals(FlushAfterClearInstruction.FLUSH_DISABLED, merged.getFlushAfterClear());
     }
 
     public class SourceClassContainingList {
@@ -94,7 +97,7 @@ class BeanCollectionInstructionsTest {
             CollectionElementType collectionElementType,
             BeanCollectionUsage beanCollectionUsage,
             AnnotationClass preferredCollectionClass,
-            Boolean flushAfterClear) {
+            FlushAfterClearInstruction flushAfterClear) {
         BeanCollectionInstructions instructions = new BeanCollectionInstructions();
         instructions.setCollectionElementType(collectionElementType);
         instructions.setBeanCollectionUsage(beanCollectionUsage);


### PR DESCRIPTION
- Replaced the OverrideConfiguration#flushAfterClear-Boolean with enum FlushAfterClearInstruction. The FlushAfterClearInstruction-enum, just like the Boolean-wrapper, allows for three values: FlushAfterClearInstruction#FLUSH_ENABLED (true), FlushAfterClearInstruction#FLUSH_DISABLED (false) and FlushAfterClearInstruction#UNSET (null). Using this enum mitigates the unpleasant usage of the Boolean-class, and should prevent NPEs.
- Replaced the usage of Boolean with the primitive boolean, wherever possible.
- Updated tests where necessary.