### PR TITLE
Added Collection and Queue mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded SLF4J 2.0.0 to 2.0.3
 - Upgraded Javassist 3.29.1-GA to 3.29.2-GA
 
+### Added
+
+- BeanMapper#map(Collection, Class) allowing users to map from a Collection to the type actual type of the 
+- Support for mapping Queue. A Queue will be mapped to an ArrayDeque by default. The order of elements is guaranteed to be preserved, except when the Queue is 
+  mapped to a Queue that inherently modifies the order of elements (e.g. PriorityQueue).
+
 
 ## [4.0.1] - 2022-09-22
 

--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -1,5 +1,6 @@
 package io.beanmapper;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +68,22 @@ public record BeanMapper(Configuration configuration) {
     }
 
     /**
+     * Maps the source collection to a new target collection.
+     *
+     * <p>The type of the target collection is determined automatically from the actual type of the source collection.
+     * If the source </p>
+     *
+     * @param collection - The source collection
+     * @param elementInCollectionClass - The class of each element in the target list.
+     * @return The target collection with mapped source collection elements.
+     * @param <S> The type up the elements in the source collection.
+     * @param <T> The type of the target, to which the source elements will be mapped.
+     */
+    public <S, T> Collection<T> map(Collection<S> collection, Class<T> elementInCollectionClass) {
+        return mapCollection(collection, elementInCollectionClass);
+    }
+
+    /**
      * Maps the source list of elements to a new target list. Convenience operator
      * @param list the source list
      * @param elementInListClass the class of each element in the target list
@@ -75,7 +92,7 @@ public record BeanMapper(Configuration configuration) {
      * @return the target list with mapped source list elements
      */
     public <S, T> List<T> map(List<S> list, Class<T> elementInListClass) {
-        return (List<T>) mapCollection(list, elementInListClass);
+        return mapCollection(list, elementInListClass);
     }
 
     /**
@@ -87,7 +104,7 @@ public record BeanMapper(Configuration configuration) {
      * @return the target set with mapped source set elements
      */
     public <S, T> Set<T> map(Set<S> set, Class<T> elementInSetClass) {
-        return (Set<T>) mapCollection(set, elementInSetClass);
+        return mapCollection(set, elementInSetClass);
     }
 
     /**
@@ -100,11 +117,11 @@ public record BeanMapper(Configuration configuration) {
      * @return the target map with literal source set keys and mapped source set values
      */
     public <K, S, T> Map<K, T> map(Map<K, S> map, Class<T> mapValueClass) {
-        return (Map<K, T>) mapCollection(map, mapValueClass);
+        return mapCollection(map, mapValueClass);
     }
 
-    private Object mapCollection(Object collection, Class<?> elementInCollection) {
-        return wrap()
+    private <S, T, E> T mapCollection(S collection, Class<E> elementInCollection) {
+        return (T) wrap()
                 .setCollectionClass(collection.getClass())
                 .setTargetClass(elementInCollection)
                 .build()

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -9,6 +9,7 @@ import io.beanmapper.annotations.LogicSecuredCheck;
 import io.beanmapper.core.collections.CollectionHandler;
 import io.beanmapper.core.collections.ListCollectionHandler;
 import io.beanmapper.core.collections.MapCollectionHandler;
+import io.beanmapper.core.collections.QueueCollectionHandler;
 import io.beanmapper.core.collections.SetCollectionHandler;
 import io.beanmapper.core.constructor.BeanInitializer;
 import io.beanmapper.core.converter.BeanConverter;
@@ -28,9 +29,10 @@ public class BeanMapperBuilder {
 
     private static final List<CollectionHandler> DEFAULT_COLLECTION_HANDLERS =
             List.of(
-                new MapCollectionHandler(),
-                new SetCollectionHandler(),
-                new ListCollectionHandler()
+                    new MapCollectionHandler(),
+                    new SetCollectionHandler(),
+                    new ListCollectionHandler(),
+                    new QueueCollectionHandler()
             );
 
     private final Configuration configuration;
@@ -158,12 +160,12 @@ public class BeanMapperBuilder {
         this.configuration.setStrictSourceSuffix(strictSourceSuffix);
         return this;
     }
-    
+
     public BeanMapperBuilder setStrictTargetSuffix(String strictTargetSuffix) {
         this.configuration.setStrictTargetSuffix(strictTargetSuffix);
         return this;
     }
-    
+
     public BeanMapperBuilder setApplyStrictMappingConvention(Boolean applyStrictMappingConvention) {
         this.configuration.setApplyStrictMappingConvention(applyStrictMappingConvention);
         return this;
@@ -188,7 +190,6 @@ public class BeanMapperBuilder {
         this.configuration.setFlushEnabled(flushEnabled);
         return this;
     }
-
 
     public BeanMapperBuilder setUseNullValue() {
         this.configuration.setUseNullValue(true);

--- a/src/main/java/io/beanmapper/core/collections/QueueCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/QueueCollectionHandler.java
@@ -1,0 +1,33 @@
+package io.beanmapper.core.collections;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import io.beanmapper.BeanMapper;
+
+public class QueueCollectionHandler extends AbstractCollectionHandler<Queue> {
+
+    @Override
+    protected void clear(Queue target) {
+        target.clear();
+    }
+
+    @Override
+    protected Queue create() {
+        return new ArrayDeque<>();
+    }
+
+    @Override
+    public Queue copy(BeanMapper beanMapper, Class collectionElementClass, Queue source, Queue target) {
+        for (var obj : source) {
+            target.add(mapItem(beanMapper, collectionElementClass, obj));
+        }
+        return target;
+    }
+
+    @Override
+    public int size(Queue targetCollection) {
+        return targetCollection.size();
+    }
+
+}

--- a/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
+++ b/src/test/java/io/beanmapper/config/BeanMapperBuilderTest.java
@@ -99,7 +99,7 @@ class BeanMapperBuilderTest {
         BeanMapper beanMapper = new BeanMapperBuilder()
                 .addCollectionHandler(new ListCollectionHandler())
                 .build();
-        assertEquals(4, beanMapper.configuration().getCollectionHandlers().size());
+        assertEquals(5, beanMapper.configuration().getCollectionHandlers().size());
     }
 
     @Test

--- a/src/test/java/io/beanmapper/testmodel/collections/CollectionPriorityQueueTarget.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollectionPriorityQueueTarget.java
@@ -1,0 +1,14 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+import io.beanmapper.annotations.BeanCollection;
+import io.beanmapper.annotations.BeanCollectionUsage;
+
+public class CollectionPriorityQueueTarget {
+
+    @BeanCollection(elementType = Long.class, preferredCollectionClass = PriorityQueue.class, beanCollectionUsage = BeanCollectionUsage.CONSTRUCT)
+    public Queue<Long> queue;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/CollectionQueueSource.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/CollectionQueueSource.java
@@ -1,0 +1,10 @@
+package io.beanmapper.testmodel.collections;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class CollectionQueueSource {
+
+    public Queue<String> queue = new ArrayDeque<>();
+
+}


### PR DESCRIPTION
- Added BeanMapper#map(Collection, Class), allowing users to map from a Collection to the actual type of the Collection automatically.
- Added QueueCollectionHandler, allowing mapping of subtypes of the Queue-interface.

Resolves #126 