### PR TITLE
Replaced NOPs in OverrideConfiguration with suitable Exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-### Changed
+### Updated
 
 - Upgraded JUnit 5.8.2 to 5.9.0
 - Upgraded SLF4J 2.0.0 to 2.0.3
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Issue [#152](https://github.com/42BV/beanmapper/issues/152) **Methods that return a Collection should never return null.**; All methods that return a
   Collection, will return an empty Collection of the target type, rather than returning null.
+- Issue [#153](https://github.com/42BV/beanmapper/issues/153) **https://github.com/42BV/beanmapper/issues/153**; Rather than using the Boolean-wrapper, all
+  occurrences of Boolean that are not absolutely necessary due to generics, have been replaced with the primitive boolean, or the
+  FlushAfterClearInstruction-enum.
 
 ### Added
 
@@ -24,11 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for mapping Queue. A Queue will be mapped to an ArrayDeque by default. The order of elements is guaranteed to be preserved, except when the Queue is 
   mapped to a Queue that inherently modifies the order of elements (e.g. PriorityQueue).
 
-### Fixed
+### Changed
 
-- Issue [#153](https://github.com/42BV/beanmapper/issues/153) **https://github.com/42BV/beanmapper/issues/153**; Rather than using the Boolean-wrapper, all 
-  occurrences of Boolean that are not absolutely necessary due to generics, have been replaced with the primitive boolean, or the 
-  FlushAfterClearInstruction-enum.
+- Methods in OverrideConfiguration that used to perform NOP, now throw a BeanConfigurationOperationNotAllowedException.
 
 
 ## [4.0.1] - 2022-09-22

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -201,7 +201,8 @@ public class BeanMapperBuilder {
         BeanMapper beanMapper = new BeanMapper(configuration);
         // Custom collection handlers must be registered before default ones
         addCollectionHandlers(customCollectionHandlers);
-        addCollectionHandlers(DEFAULT_COLLECTION_HANDLERS);
+        if (this.configuration instanceof CoreConfiguration)
+            addCollectionHandlers(DEFAULT_COLLECTION_HANDLERS);
         // Custom bean converters must be registered before default ones
         addCustomConverters();
         if (configuration.isAddDefaultConverters()) {

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -13,6 +13,7 @@ import io.beanmapper.core.constructor.BeanInitializer;
 import io.beanmapper.core.converter.BeanConverter;
 import io.beanmapper.core.unproxy.BeanUnproxy;
 import io.beanmapper.dynclass.ClassStore;
+import io.beanmapper.exceptions.BeanConfigurationOperationNotAllowedException;
 
 public class OverrideConfiguration implements Configuration {
 
@@ -172,7 +173,8 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void withoutDefaultConverters() {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to modify default converters on the override configuration, works only for core configurations");
     }
 
     @Override
@@ -254,12 +256,14 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void addLogicSecuredCheck(LogicSecuredCheck logicSecuredCheck) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a LogicSecuredCheck on the override configuration, works only for core configurations");
     }
 
     @Override
     public void addCollectionHandler(CollectionHandler collectionHandler) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a CollectionHandler on the override configuration, works only for core configurations");
     }
 
     @Override
@@ -274,27 +278,32 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void addProxySkipClass(Class<?> clazz) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a ProxySkip-class on the override configuration, works only for core configurations");
     }
 
     @Override
     public void addPackagePrefix(Class<?> clazz) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a package prefix on the override configuration, works only for core configurations");
     }
 
     @Override
     public void addPackagePrefix(String packagePrefix) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a package prefix on the override configuration, works only for core configurations");
     }
 
     @Override
     public void addAfterClearFlusher(AfterClearFlusher afterClearFlusher) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a AfterClearFlusher on the override configuration, works only for core configurations");
     }
 
     @Override
     public void setRoleSecuredCheck(RoleSecuredCheck roleSecuredCheck) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add a RoleSecuredCheck on the override configuration, works only for core configurations");
     }
 
     @Override
@@ -309,7 +318,8 @@ public class OverrideConfiguration implements Configuration {
 
     @Override
     public void setBeanUnproxy(BeanUnproxy beanUnproxy) {
-        // not supported for override options
+        throw new BeanConfigurationOperationNotAllowedException(
+                "Illegal to add BeanUnproxy on the override configuration, works only for core configurations");
     }
 
     @Override

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -1367,7 +1367,6 @@ class BeanMapperTest {
                 .build().wrap()
                 .setFlushEnabled(true)
                 .setFlushAfterClear(FlushAfterClearInstruction.FLUSH_ENABLED)
-                .addAfterClearFlusher(afterClearFlusher)
                 .build();
         CollSourceClearFlush source = new CollSourceClearFlush() {{
             items.add("A");

--- a/src/test/java/io/beanmapper/config/OverrideConfigurationTest.java
+++ b/src/test/java/io/beanmapper/config/OverrideConfigurationTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.core.constructor.DefaultBeanInitializer;
+import io.beanmapper.exceptions.BeanConfigurationOperationNotAllowedException;
 import io.beanmapper.strategy.ConstructorArguments;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -35,12 +36,12 @@ public class OverrideConfigurationTest {
 
     @Test
     void unsupportedCalls() {
-        overrideConfiguration.withoutDefaultConverters();
-        overrideConfiguration.addProxySkipClass(null);
-        overrideConfiguration.addPackagePrefix((String) null);
-        overrideConfiguration.addPackagePrefix((Class) null);
-        overrideConfiguration.addAfterClearFlusher(null);
-        overrideConfiguration.setBeanUnproxy(null);
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.withoutDefaultConverters());
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addProxySkipClass(null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addPackagePrefix((String) null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addPackagePrefix((Class) null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addAfterClearFlusher(null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.setBeanUnproxy(null));
     }
 
     @Test


### PR DESCRIPTION
- OverrideConfiguration#withoutDefaultConverters throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#addLogicSecuredCheck throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#addCollectionHandler throws a BeanConfigurationOperationNotAllowedException(String)
- OverrideConfiguration#addProxySkipClass throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#addPackagePrefix(Class<?>) throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#addPackagePrefix(String) throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#addAfterClearFlusher throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#setRoleSecuredCheck throws a BeanConfigurationOperationNotAllowedException(String).
- OverrideConfiguration#setBeanUnproxy throws a BeanConfigurationOperationNotAllowedException(String).
- Updated tests.
- Updated CHANGELOG.md.