### PR TITLE
Added Mapping to and from Record-classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Issue [#130](https://github.com/42BV/beanmapper/issues/130) **@BeanConstruct does not map collection constructor arguments**; Added
   DefaultBeanInitializer#mapParameterizedArguments(Type[], Object[]), allowing BeanMapper to properly map constructor parameters with a type-parameter, when
   using the @BeanConstruct-annotation.
+- Issue [#149](https://github.com/42BV/beanmapper/issues/149) **Support mapping of JDK 16+ records to classes.**; Added support for mapping record through the
+  usual BeanMapper#map(Object, Class<?>)-method.
 - Issue [#152](https://github.com/42BV/beanmapper/issues/152) **Methods that return a Collection should never return null.**; All methods that return a
   Collection, will return an empty Collection of the target type, rather than returning null.
 - Issue [#153](https://github.com/42BV/beanmapper/issues/153) **https://github.com/42BV/beanmapper/issues/153**; Rather than using the Boolean-wrapper, all
@@ -37,12 +39,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   mapped to a Queue that inherently modifies the order of elements (e.g. PriorityQueue).
 - BeanMapper#map(Queue, Class) allowing users to map a Queue to a new Queue, mapping the elements of the source to the target class.
 - BeanMapper#map(Object[], Class) allowing users to map an array to an array with elements of the type of the target class.
+- Support for mapping to and from JDK16 record-classes.
+- @RecordConstruct-annotation, used to give BeanMapper instructions on how to map a record.
+- RecordConstructMode-enum, which allows the user to exclude certain constructors from being used to map a record, or force one to be used.
+- Configuration#addCustomDefaultValueForClass(Class<?>, Object value) and Configuration#getDefaultValueForClass(Class<?>), which can be used to define default
+  values for classes during runtime.
+- RecordToAnyConverter, which creates a dynamic class based off of the given Record, which contains only public fields, corresponding to the RecordComponents.
+  The dynamic class is then filled with values from the source Record, and used as an intermediary between the source and the target.
+- MappingException, to serve as a common super-class for Exceptions thrown while mapping classes, and records.
+- Default values for Optional, List, Set and Map in the DefaultValues.
+- BeanMapper#map(Object, ParameterizedType), allowing for smarter mapping of collections and optionals.
 
 ### Changed
 
 - Methods in OverrideConfiguration that used to perform NOP, now throw a BeanConfigurationOperationNotAllowedException.
 - Removed deprecated method BeanMapper#config(), BeanMapper#wrapConfig().
 - Removed deprecated class BeanMapperAware.
+- @BeanAlias now applicable to RecordComponent.
+- Expanded the use of type parameters to various methods throughout the library, including the BeanMapper-class.
+- BeanConverters may be offered null-values now. Will default to returning the default value for the relevant type.
+
+### Removed
+
+- slf4j-api dependency, as it is transitive through jcl-over-slf4j.
 
 ## [4.0.1] - 2022-09-22
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.beanmapper</groupId>
@@ -93,12 +94,6 @@
         </dependency>
 
         <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>

--- a/src/main/java/io/beanmapper/annotations/BeanAlias.java
+++ b/src/main/java/io/beanmapper/annotations/BeanAlias.java
@@ -6,9 +6,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Setting a value makes the property available for constructor or other fields to map.
+ * BeanAlias provides a way for a source-class to indicate which field in the target-class the annotated field should be
+ * mapped to.
+ *
+ * <p>The BeanAlias-annotation works well in concert with the {@link BeanProperty}-annotation.</p>
+ *
+ * @apiNote While a target-class may contain field annotated with the BeanAlias-annotation, during mapping, those
+ *          annotations will be ignored. For equivalent functionality on the target-side, use the
+ *          BeanProperty-annotation on the relevant fields.
+ * @see BeanProperty
  */
-@Target({ ElementType.FIELD, ElementType.METHOD })
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.RECORD_COMPONENT })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BeanAlias {
 

--- a/src/main/java/io/beanmapper/annotations/RecordConstruct.java
+++ b/src/main/java/io/beanmapper/annotations/RecordConstruct.java
@@ -1,0 +1,61 @@
+package io.beanmapper.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.RecordComponent;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.exceptions.RecordConstructorConflictException;
+import io.beanmapper.exceptions.RecordNoAvailableConstructorsExceptions;
+
+/**
+ * An annotation applicable to {@link Record}-classes, that can be used to force {@link BeanMapper} to use a specific constructor of a
+ * record.
+ *
+ * <p>By default, BeanMapper will use the
+ * <a href="https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10.4">canonical constructor</a> of a
+ * record. However, when a source-class contains fewer fields than the amount of {@link RecordComponent}-objects of the record,
+ * it may be wise to declare an overloaded constructor that allows the user to set only those fields that are present in
+ * the source, and fills the remaining fields with default values.</p>
+ *
+ * <p>If a record contains multiple overloaded constructors, this annotation may offer some clarity. By setting the
+ * {@link #constructMode}-field of the annotation, the user may give hints on which constructor BeanMapper should use. This is
+ * especially useful in cases where BeanMapper should only use a specific constructor, or should exclude certain
+ * from consideration.</p>
+ *
+ * @apiNote <p>Annotating multiple constructors with the {@link RecordConstructMode#FORCE}-option will lead to a
+ * {@link RecordConstructorConflictException} being thrown.</p>
+ *
+ * <p>Annotating a single constructor with {@link RecordConstructMode#FORCE}, and (an)other constructor(s) with
+ * {@link RecordConstructMode#ON_DEMAND} will always result in the constructor annotated with the
+ * RecordConstructMode.FORCE-option being used. This will, however, not throw an Exception, as it will not cause any
+ * issues for BeanMapper.</p>
+ *
+ * <p>Annotating a constructor with the {@link RecordConstructMode#EXCLUDE}-option, will actively exclude that
+ * constructor from consideration.</p>
+ *
+ * <p>Annotating all constructors with the RecordConstructMode.EXCLUDE-option, will result in a
+ * {@link RecordNoAvailableConstructorsExceptions} being thrown.</p>
+ *
+ * @see RecordConstructMode
+ * @see io.beanmapper.strategy.MapToRecordStrategy
+ * @see io.beanmapper.utils.Records
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.CONSTRUCTOR })
+public @interface RecordConstruct {
+
+    /**
+     * Should contain the names of the fields that need to be used to invoke the constructor.
+     *
+     * @return The names of the fields that will be used to invoke the constructor.
+     */
+    String[] value() default "";
+
+    RecordConstructMode constructMode() default RecordConstructMode.ON_DEMAND;
+
+    boolean allowNull() default false;
+
+}

--- a/src/main/java/io/beanmapper/annotations/RecordConstructMode.java
+++ b/src/main/java/io/beanmapper/annotations/RecordConstructMode.java
@@ -1,0 +1,15 @@
+package io.beanmapper.annotations;
+
+/**
+ * An enum used to set whether a constructor of a Record should be considered for mapping, force to be used for mapping,
+ * or excluded from mapping.
+ *
+ * @see RecordConstruct
+ */
+public enum RecordConstructMode {
+
+    ON_DEMAND,
+    FORCE,
+    EXCLUDE
+
+}

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -20,6 +20,7 @@ import io.beanmapper.core.converter.impl.NumberToNumberConverter;
 import io.beanmapper.core.converter.impl.ObjectToStringConverter;
 import io.beanmapper.core.converter.impl.OptionalToObjectConverter;
 import io.beanmapper.core.converter.impl.PrimitiveConverter;
+import io.beanmapper.core.converter.impl.RecordToAnyConverter;
 import io.beanmapper.core.converter.impl.StringToBigDecimalConverter;
 import io.beanmapper.core.converter.impl.StringToBooleanConverter;
 import io.beanmapper.core.converter.impl.StringToIntegerConverter;
@@ -38,9 +39,9 @@ public class BeanMapperBuilder {
 
     private final Configuration configuration;
 
-    private List<BeanConverter> customBeanConverters = new ArrayList<>();
+    private final List<BeanConverter> customBeanConverters = new ArrayList<>();
 
-    private List<CollectionHandler> customCollectionHandlers = new ArrayList<>();
+    private final List<CollectionHandler> customCollectionHandlers = new ArrayList<>();
 
     public BeanMapperBuilder() {
         this.configuration = new CoreConfiguration();
@@ -197,6 +198,20 @@ public class BeanMapperBuilder {
         return this;
     }
 
+    /**
+     * Adds a mapping for a default value to the configuration.
+     *
+     * @param targetClass The class that the value is the default for.
+     * @param value The value that will serve as the default for the target-class.
+     * @return This instance.
+     * @param <T> The type op the targetClass.
+     * @param <V> The type of the value.
+     */
+    public <T, V> BeanMapperBuilder addCustomDefaultValue(Class<T> targetClass, V value) {
+        this.configuration.addCustomDefaultValueForClass(targetClass, value);
+        return this;
+    }
+
     public BeanMapper build() {
         BeanMapper beanMapper = new BeanMapper(configuration);
         // Custom collection handlers must be registered before default ones
@@ -235,6 +250,7 @@ public class BeanMapperBuilder {
         attachConverter(new NumberToNumberConverter());
         attachConverter(new ObjectToStringConverter());
         attachConverter(new OptionalToObjectConverter());
+        attachConverter(new RecordToAnyConverter());
 
         for (CollectionHandler collectionHandler : configuration.getCollectionHandlers()) {
             attachConverter(new CollectionConverter(collectionHandler));

--- a/src/main/java/io/beanmapper/config/Configuration.java
+++ b/src/main/java/io/beanmapper/config/Configuration.java
@@ -224,7 +224,7 @@ public interface Configuration {
      * it will use this class over the one provided by the collection handler.
      * @return the collection class to prefer for instantiation
      */
-    Class<?> getPreferredCollectionClass();
+    <T> Class<T> getPreferredCollectionClass();
 
     /**
      * Sets the preferred collection class to be instantiated. If it has this choice,
@@ -419,4 +419,32 @@ public interface Configuration {
      */
     void setFlushAfterClear(FlushAfterClearInstruction flushAfterClear);
 
+    /**
+     * Allows the user to set a default value for a given type.
+     *
+     * <p>While the standard implementation of BeanMapper contains a utility-class
+     * {@link io.beanmapper.utils.DefaultValues}, the map within is far from exhaustive. Furthermore, custom default
+     * values can serve as a useful compatibility feature for projects that would prefer different defaults.</p>
+     *
+     * @param target The target class.
+     * @param value The default value for the given target class.
+     * @param <T> The type of the target.
+     * @param <V> The type of the value.
+     */
+    <T, V> void addCustomDefaultValueForClass(Class<T> target, V value);
+
+    /**
+     * Gets the default for the given target class.
+     *
+     * <p>Any implementation of this method must first check the registered custom default values for a suitable value,
+     * if a container for custom defaults exists. Afterwards, the method may check a parent-configuration's custom
+     * defaults, or simply refer to the defaults in {@link io.beanmapper.utils.DefaultValues}.</p>
+     *
+     * @param targetClass The target class
+     * @return The value associated with the given target class, based off of the values set in the custom default
+     *         values container, or the DefaultValues-class.
+     * @param <T> The type of the target-class.
+     * @param <V> The type of the associated value.
+     */
+    <T, V> V getDefaultValueForClass(Class<T> targetClass);
 }

--- a/src/main/java/io/beanmapper/config/CoreConfiguration.java
+++ b/src/main/java/io/beanmapper/config/CoreConfiguration.java
@@ -18,6 +18,7 @@ import io.beanmapper.core.unproxy.DefaultBeanUnproxy;
 import io.beanmapper.core.unproxy.SkippingBeanUnproxy;
 import io.beanmapper.dynclass.ClassStore;
 import io.beanmapper.exceptions.BeanConfigurationOperationNotAllowedException;
+import io.beanmapper.utils.DefaultValues;
 
 public class CoreConfiguration implements Configuration {
 
@@ -99,6 +100,8 @@ public class CoreConfiguration implements Configuration {
      * is to skip the mapping operation if a source value is null.
      */
     private boolean useNullValue;
+
+    private Map<Class<?>, Object> customDefaultValueMap = new HashMap<>();
 
     @Override
     public List<String> getDownsizeTarget() {
@@ -421,4 +424,21 @@ public class CoreConfiguration implements Configuration {
                 "Illegal to set flush after clear on the core configuration");
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T, V> V getDefaultValueForClass(Class<T> targetClass) {
+        return this.customDefaultValueMap.containsKey(targetClass)
+                ? (V) this.customDefaultValueMap.get(targetClass)
+                : DefaultValues.defaultValueFor(targetClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T, V> void addCustomDefaultValueForClass(Class<T> targetClass, V value) {
+        this.customDefaultValueMap.put(targetClass, value);
+    }
 }

--- a/src/main/java/io/beanmapper/config/OverrideConfiguration.java
+++ b/src/main/java/io/beanmapper/config/OverrideConfiguration.java
@@ -2,6 +2,7 @@ package io.beanmapper.config;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,39 +20,41 @@ public class OverrideConfiguration implements Configuration {
 
     private final Configuration parentConfiguration;
 
-    private OverrideField<BeanInitializer> beanInitializer;
+    private final OverrideField<BeanInitializer> beanInitializer;
 
-    private List<BeanConverter> beanConverters = new ArrayList<>();
+    private final List<BeanConverter> beanConverters = new ArrayList<>();
 
-    private List<BeanPair> beanPairs = new ArrayList<>();
+    private final List<BeanPair> beanPairs = new ArrayList<>();
 
-    private OverrideField<List<String>> downsizeSourceFields;
+    private final OverrideField<List<String>> downsizeSourceFields;
 
-    private OverrideField<List<String>> downsizeTargetFields;
+    private final OverrideField<List<String>> downsizeTargetFields;
 
     private Class targetClass;
 
     private Object target;
 
-    private OverrideField<Object> parent;
+    private final OverrideField<Object> parent;
 
     private Class collectionClass;
 
-    private OverrideField<Boolean> converterChoosable;
+    private final OverrideField<Boolean> converterChoosable;
 
-    private OverrideField<StrictMappingProperties> strictMappingProperties;
+    private final OverrideField<StrictMappingProperties> strictMappingProperties;
 
     private BeanCollectionUsage collectionUsage = null;
 
     private Class<?> preferredCollectionClass = null;
 
-    private OverrideField<Boolean> enforcedSecuredProperties;
+    private final OverrideField<Boolean> enforcedSecuredProperties;
 
-    private OverrideField<Boolean> useNullValue;
+    private final OverrideField<Boolean> useNullValue;
 
-    private OverrideField<FlushAfterClearInstruction> flushAfterClear;
+    private final OverrideField<FlushAfterClearInstruction> flushAfterClear;
 
-    private OverrideField<Boolean> flushEnabled;
+    private final OverrideField<Boolean> flushEnabled;
+
+    private final Map<Class<?>, Object> customDefaultValues;
 
     public OverrideConfiguration(Configuration configuration) {
         if (configuration == null) {
@@ -68,6 +71,7 @@ public class OverrideConfiguration implements Configuration {
         this.useNullValue = new OverrideField<>(configuration::getUseNullValue);
         this.strictMappingProperties = new OverrideField<>(configuration::getStrictMappingProperties);
         this.enforcedSecuredProperties = new OverrideField<>(configuration::getEnforceSecuredProperties);
+        this.customDefaultValues = new HashMap<>();
     }
 
     @Override
@@ -405,6 +409,24 @@ public class OverrideConfiguration implements Configuration {
     @Override
     public void setFlushAfterClear(FlushAfterClearInstruction flushAfterClear) {
         this.flushAfterClear.set(flushAfterClear);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T, V> void addCustomDefaultValueForClass(Class<T> target, V value) {
+        this.customDefaultValues.put(target, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T, V> V getDefaultValueForClass(Class<T> targetClass) {
+        return this.customDefaultValues.containsKey(targetClass)
+                ? (V) this.customDefaultValues.get(targetClass)
+                : this.parentConfiguration.getDefaultValueForClass(targetClass);
     }
 
 }

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -129,6 +129,7 @@ public class BeanMatchStore {
 
         Map<String, BeanProperty> ourCurrentNodes = ourNodes;
         List<PropertyAccessor> accessors = PropertyAccessors.getAll(ourType);
+
         for (PropertyAccessor accessor : accessors) {
 
             BeanPropertyAccessType accessType = matchupDirection.accessType(accessor);
@@ -137,7 +138,7 @@ public class BeanMatchStore {
             }
 
             // Ignore fields
-            if (accessor.findAnnotation(BeanIgnore.class) != null) {
+            if (accessor.isAnnotationPresent(BeanIgnore.class)) {
                 continue;
             }
 
@@ -147,7 +148,7 @@ public class BeanMatchStore {
                     dealWithBeanProperty(matchupDirection, otherNodes, otherType, accessor);
 
             // Unwrap the fields which exist in the unwrap class
-            BeanProperty currentBeanProperty = null;
+            BeanProperty currentBeanProperty;
             try {
                 currentBeanProperty = new BeanPropertyCreator(
                         matchupDirection, ourType, accessor.getName()).determineNodesForPath(precedingBeanProperty);
@@ -169,7 +170,7 @@ public class BeanMatchStore {
                     currentBeanProperty,
                     accessor.findAnnotation(BeanLogicSecured.class));
 
-            if (accessor.findAnnotation(BeanAlias.class) != null) {
+            if (accessor.isAnnotationPresent(BeanAlias.class)) {
                 BeanAlias beanAlias = accessor.findAnnotation(BeanAlias.class);
                 if (aliases.containsKey(beanAlias.value())) {
                     throw new IllegalArgumentException("There is already a BeanAlias with key " + beanAlias.value());
@@ -177,7 +178,7 @@ public class BeanMatchStore {
                 aliases.put(beanAlias.value(), currentBeanProperty);
             }
 
-            if (accessor.findAnnotation(BeanUnwrap.class) != null) {
+            if (accessor.isAnnotationPresent(BeanUnwrap.class)) {
                 ourCurrentNodes = getAllFields(
                         ourCurrentNodes,
                         otherNodes,
@@ -263,7 +264,7 @@ public class BeanMatchStore {
             BeanPropertyMatchupDirection matchupDirection, Map<String, BeanProperty> otherNodes,
             Class<?> otherType, PropertyAccessor accessor) {
         BeanPropertyWrapper wrapper = new BeanPropertyWrapper(accessor.getName());
-        if (accessor.findAnnotation(io.beanmapper.annotations.BeanProperty.class) != null) {
+        if (accessor.isAnnotationPresent(io.beanmapper.annotations.BeanProperty.class)) {
             wrapper.setMustMatch();
             wrapper.setName(getBeanPropertyName(accessor.findAnnotation(io.beanmapper.annotations.BeanProperty.class)));
             // Get the other field from the location that is specified in the beanProperty annotation.
@@ -277,7 +278,7 @@ public class BeanMatchStore {
                 if (logger.isDebugEnabled()) {
                     logger.debug("""
                             BeanNoSuchPropertyException thrown by BeanMatchStore#dealWithBeanProperty(BeanPropertyMatchupDirection, Map<String, BeanProperty>, Class, PropertyAccessor), for {}.
-                            {}""", accessor.getName(), err.getMessage());
+                            {}""", wrapper.getName(), err.getMessage());
                 }
             }
         }

--- a/src/main/java/io/beanmapper/core/BeanPropertyAccessType.java
+++ b/src/main/java/io/beanmapper/core/BeanPropertyAccessType.java
@@ -10,7 +10,7 @@ public enum BeanPropertyAccessType {
 
     FIELD {
         @Override
-        public Type getGenericType(Class containingClass, PropertyAccessor accessor) {
+        public <T> Type getGenericType(Class<T> containingClass, PropertyAccessor accessor) {
             String fieldName = accessor.getName();
             Class<?> classWithField = getFirstClassContainingField(containingClass, fieldName);
             if (classWithField == null) {
@@ -26,33 +26,34 @@ public enum BeanPropertyAccessType {
     },
     SETTER {
         @Override
-        public Type getGenericType(Class containingClass, PropertyAccessor accessor) {
+        public <T> Type getGenericType(Class<T> containingClass, PropertyAccessor accessor) {
             return accessor.getWriteMethod().getGenericParameterTypes()[0];
         }
     },
     GETTER {
         @Override
-        public Type getGenericType(Class containingClass, PropertyAccessor accessor) {
+        public <T> Type getGenericType(Class<T> containingClass, PropertyAccessor accessor) {
             return accessor.getReadMethod().getGenericReturnType();
         }
     },
     NO_ACCESS {
         @Override
-        public ParameterizedType getGenericType(Class containingClass, PropertyAccessor accessor) {
+        public <T> ParameterizedType getGenericType(Class<T> containingClass, PropertyAccessor accessor) {
             throw new BeanPropertyAccessException("The field " + accessor.getName() + " cannot be accessed");
         }
     };
 
-    private static Class getFirstClassContainingField(Class<?> currentClass, String fieldName) {
+    private static <T> Class<? super T> getFirstClassContainingField(final Class<T> currentClass, final String fieldName) {
         Field[] allFields = currentClass.getDeclaredFields();
+        Class<? super T> unproxied = currentClass;
         while (!containsField(fieldName, allFields)) {
-            currentClass = currentClass.getSuperclass();
-            if (currentClass == null || Object.class.equals(currentClass)) {
+            unproxied = unproxied.getSuperclass();
+            if (unproxied == null || Object.class.equals(currentClass)) {
                 return null;
             }
-            allFields = currentClass.getDeclaredFields();
+            allFields = unproxied.getDeclaredFields();
         }
-        return currentClass;
+        return unproxied;
     }
 
     private static boolean containsField(String fieldName, Field[] fields) {
@@ -64,6 +65,6 @@ public enum BeanPropertyAccessType {
         return false;
     }
 
-    public abstract Type getGenericType(Class containingClass, PropertyAccessor accessor);
+    public abstract <T> Type getGenericType(Class<T> containingClass, PropertyAccessor accessor);
 
 }

--- a/src/main/java/io/beanmapper/core/BeanPropertyMatch.java
+++ b/src/main/java/io/beanmapper/core/BeanPropertyMatch.java
@@ -141,7 +141,7 @@ public class BeanPropertyMatch {
     }
 
     protected boolean hasAnnotation(BeanProperty beanProperty, Class<? extends Annotation> annotationClass) {
-        return beanProperty.getAccessor().findAnnotation(annotationClass) != null;
+        return beanProperty.getAccessor().isAnnotationPresent(annotationClass);
     }
 
     public Object getSourceDefaultValue() {

--- a/src/main/java/io/beanmapper/core/MatchedBeanPropertyPair.java
+++ b/src/main/java/io/beanmapper/core/MatchedBeanPropertyPair.java
@@ -2,9 +2,7 @@ package io.beanmapper.core;
 
 public record MatchedBeanPropertyPair(BeanProperty sourceBeanProperty, BeanProperty targetBeanProperty) {
 
-    public MatchedBeanPropertyPair(BeanProperty sourceBeanProperty, BeanProperty targetBeanProperty) {
-        this.sourceBeanProperty = sourceBeanProperty;
-        this.targetBeanProperty = targetBeanProperty;
+    public MatchedBeanPropertyPair {
         setMatchedBeanProperty(sourceBeanProperty);
         setMatchedBeanProperty(targetBeanProperty);
     }

--- a/src/main/java/io/beanmapper/core/constructor/DefaultBeanInitializer.java
+++ b/src/main/java/io/beanmapper/core/constructor/DefaultBeanInitializer.java
@@ -44,11 +44,11 @@ public class DefaultBeanInitializer implements BeanInitializer {
         for (var i = 0; i < arguments.length; ++i) {
             var argument = arguments[i];
             if (argument instanceof Collection<?> collection) {
-                argument = beanMapper.map(collection, (Class<?>) ((ParameterizedType) constructorParameterTypes[i]).getActualTypeArguments()[0]);
+                argument = beanMapper.map(collection, (ParameterizedType) constructorParameterTypes[i]);
             } else if (argument instanceof Map<?, ?> map) {
-                argument = beanMapper.map(map, (Class<?>) ((ParameterizedType) constructorParameterTypes[i]).getActualTypeArguments()[1]);
+                argument = beanMapper.map(map, (ParameterizedType) constructorParameterTypes[i]);
             } else if (argument instanceof Optional<?> optional) {
-                argument = beanMapper.map(optional, (Class<?>) ((ParameterizedType) constructorParameterTypes[i]).getActualTypeArguments()[0]);
+                argument = beanMapper.map(optional, (ParameterizedType) constructorParameterTypes[i]);
             }
             mappedArguments[i] = argument;
         }

--- a/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/AbstractBeanConverter.java
@@ -44,17 +44,17 @@ public abstract class AbstractBeanConverter<S, T> implements BeanConverter {
     /**
      * {@inheritDoc}
      */
-    @Override
     @SuppressWarnings("unchecked")
-    public final Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
+    public final <U, R> R convert(BeanMapper beanMapper, U source, Class<R> targetClass, BeanPropertyMatch beanPropertyMatch) {
         this.beanMapper = beanMapper;
         if (source == null) {
-            Check.argument(!targetClass.isPrimitive(), "Cannot convert null into primitive.");
+            if (beanMapper != null)
+                beanMapper.getConfiguration().getDefaultValueForClass(targetClass);
             return null;
         }
         Check.argument(isMatchingSource(source.getClass()), "Unsupported source class.");
         Check.argument(isMatchingTarget(targetClass), "Unsupported target class.");
-        return doConvert((S) source, (Class<T>) targetClass);
+        return (R) doConvert((S) source, (Class<? extends T>) targetClass);
     }
 
     /**

--- a/src/main/java/io/beanmapper/core/converter/BeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/BeanConverter.java
@@ -19,7 +19,7 @@ public interface BeanConverter {
      * @param beanPropertyMatch information on the field pair (source / target)
      * @return the converted source instance
      */
-    Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch);
+    <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch);
 
     /**
      * Determines if the conversion of our source type to a 

--- a/src/main/java/io/beanmapper/core/converter/SimpleBeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/SimpleBeanConverter.java
@@ -25,7 +25,7 @@ public abstract class SimpleBeanConverter<S, T> extends AbstractBeanConverter<S,
      * @param sourceClass the source class
      * @param targetClass the target class
      */
-    protected SimpleBeanConverter(Class<?> sourceClass, Class<?> targetClass) {
+    protected SimpleBeanConverter(Class<? extends S> sourceClass, Class<? extends T> targetClass) {
         super(sourceClass, targetClass);
     }
 

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -5,28 +5,26 @@ import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.collections.CollectionHandler;
 import io.beanmapper.core.converter.BeanConverter;
 
-public class CollectionConverter<T> implements BeanConverter {
+public class CollectionConverter implements BeanConverter {
 
-    private final CollectionHandler<T> collectionHandler;
+    private final CollectionHandler<?> collectionHandler;
 
-    public CollectionConverter(CollectionHandler<T> collectionHandler) {
+    public CollectionConverter(CollectionHandler<?> collectionHandler) {
         this.collectionHandler = collectionHandler;
     }
 
     @Override
-    public T convert(
+    public <R, U> U convert(
             BeanMapper beanMapper,
-            Object source,
-            Class<?> targetClass,
+            R source,
+            Class<U> targetClass,
             BeanPropertyMatch beanPropertyMatch) {
 
-        T sourceCollection = (T) source;
-
-        if (beanPropertyMatch.getCollectionInstructions() == null) {
-            return sourceCollection;
+        if (beanPropertyMatch == null || beanPropertyMatch.getCollectionInstructions() == null) {
+            return targetClass.cast(source);
         }
 
-        return (T) beanMapper.wrap()
+        return beanMapper.wrap()
                 .setCollectionClass(collectionHandler.getType())
                 .setCollectionUsage(beanPropertyMatch.getCollectionInstructions().getBeanCollectionUsage())
                 .setPreferredCollectionClass(beanPropertyMatch.getCollectionInstructions().getPreferredCollectionClass().getAnnotationClass())
@@ -35,7 +33,7 @@ public class CollectionConverter<T> implements BeanConverter {
                 .setTarget(beanPropertyMatch.getTargetObject())
                 .setUseNullValue()
                 .build()
-                .map(sourceCollection);
+                .map(source);
     }
 
     @Override

--- a/src/main/java/io/beanmapper/core/converter/impl/NumberToNumberConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/NumberToNumberConverter.java
@@ -36,9 +36,9 @@ public class NumberToNumberConverter implements BeanConverter {
      * then converting that string back into the target number.
      */
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
+    public <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch) {
         if (source == null || source.getClass().equals(targetClass) || (beanPropertyMatch != null && beanPropertyMatch.getSourceClass().equals(targetClass))) {
-            return source;
+            return (T) source;
         }
         Object sourceAsString = beanMapper
                 .wrap()

--- a/src/main/java/io/beanmapper/core/converter/impl/OptionalToObjectConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/OptionalToObjectConverter.java
@@ -8,14 +8,11 @@ import io.beanmapper.core.converter.BeanConverter;
 
 public class OptionalToObjectConverter implements BeanConverter {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
+    public <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch) {
         Object obj = ((Optional<?>) source).orElse(null);
         if (obj != null && obj.getClass().equals(targetClass)) {
-            return obj;
+            return (T) obj;
         }
         return beanMapper.map(obj, targetClass);
     }

--- a/src/main/java/io/beanmapper/core/converter/impl/PrimitiveConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/PrimitiveConverter.java
@@ -40,9 +40,8 @@ public class PrimitiveConverter implements BeanConverter {
      * {@inheritDoc}
      */
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
-        Check.argument(source != null, "Cannot convert null into primitive value.");
-        return source; // Value will automatically be boxed or unboxed
+    public <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch) {
+        return source != null ? (T) source : beanMapper.getConfiguration().getDefaultValueForClass(targetClass); // Value will automatically be boxed or unboxed
     }
 
     /**

--- a/src/main/java/io/beanmapper/core/converter/impl/RecordToAnyConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/RecordToAnyConverter.java
@@ -1,0 +1,87 @@
+package io.beanmapper.core.converter.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.annotations.BeanAlias;
+import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.core.BeanPropertyMatch;
+import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.exceptions.RecordMappingToIntermediaryException;
+import io.beanmapper.utils.Records;
+
+public class RecordToAnyConverter implements BeanConverter {
+
+    @Override
+    public <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch) {
+        Map<String, RecordComponent> mappedComponents = new HashMap<>();
+        Arrays.stream(source.getClass().getRecordComponents()).forEach(component -> {
+            if (component.isAnnotationPresent(BeanAlias.class)) {
+                mappedComponents.put(component.getAnnotation(BeanAlias.class).value(), component);
+            } else {
+                mappedComponents.put(component.getName(), component);
+            }
+        });
+
+        try {
+            Class<?> intermediaryClass = beanMapper.getConfiguration().getClassStore().getOrCreateGeneratedClass(source.getClass(),
+                    List.of(Records.getRecordFieldNames(
+                            (Class<? extends Record>) source.getClass())), null);
+            Object intermediaryObject = intermediaryClass.cast(
+                    this.copyRecordComponentsToIntermediary((Record) source, intermediaryClass.getConstructors()[0].newInstance()));
+            return beanMapper.map(intermediaryObject, targetClass);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchFieldException | NoSuchMethodException e) {
+            throw new RecordMappingToIntermediaryException(source.getClass(), e);
+        }
+    }
+
+    @Override
+    public boolean match(Class<?> sourceClass, Class<?> targetClass) {
+        return sourceClass.isRecord();
+    }
+
+    /**
+     * Compiles a map of fields, using the field-names as the key, and calls {@link RecordToAnyConverter#copyFieldsToIntermediary(Object, Map)} in order to map
+     * the copy the values of the fields in the recordClass to the intermediary.
+     *
+     * @param recordClass Record from which the RecordComponents will be copied to the intermediary object.
+     * @param intermediary Intermediary object to which the RecordComponents will be mapped.
+     * @return The intermediary object to which the RecordComponents have been copied.
+     * @param <R> The type of the record class.
+     * @param <T> The type of the intermediary class.
+     */
+    private <R extends Record, T> T copyRecordComponentsToIntermediary(R recordClass, T intermediary)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
+        Map<String, Object> fieldMap = new HashMap<>();
+        for (var field : intermediary.getClass().getDeclaredFields()) {
+            Method getter = recordClass.getClass().getDeclaredMethod(field.getName());
+            fieldMap.put(field.getName(), getter.invoke(recordClass));
+        }
+        return copyFieldsToIntermediary(intermediary, fieldMap);
+    }
+
+    /**
+     * Copies the values in the fieldMap to the given intermediary object.
+     *
+     * @param intermediary The intermediary object to which the fields in the fieldMap will be copied.
+     * @param fieldMap Contains the fields that will be copied to the intermediary object.
+     * @return The intermediary object containing the fields from the fieldMap.
+     * @param <T> The type of the intermediary object.
+     */
+    private <T> T copyFieldsToIntermediary(T intermediary, Map<String, Object> fieldMap) throws NoSuchFieldException, IllegalAccessException {
+        BeanMapper beanMapper = new BeanMapperBuilder().setConverterChoosable(true).setUseNullValue().build();
+        for (Map.Entry<String, Object> fieldEntry : fieldMap.entrySet()) {
+            if (!fieldEntry.getValue().getClass().equals(intermediary.getClass().getDeclaredField(fieldEntry.getKey()).getType())) {
+                fieldEntry.setValue(beanMapper.map(fieldEntry.getValue(), intermediary.getClass().getDeclaredField(fieldEntry.getKey()).getType()));
+            }
+            intermediary.getClass().getDeclaredField(fieldEntry.getKey()).set(intermediary, fieldEntry.getValue());
+        }
+        return intermediary;
+    }
+}

--- a/src/main/java/io/beanmapper/core/generics/DirectedBeanProperty.java
+++ b/src/main/java/io/beanmapper/core/generics/DirectedBeanProperty.java
@@ -52,7 +52,7 @@ public class DirectedBeanProperty {
             BeanPropertyAccessType accessType,
             Class containingClass,
             PropertyAccessor accessor) {
-        Type type = accessType.getGenericType(containingClass, accessor);
+        Type type = (containingClass.isRecord()) ? BeanPropertyAccessType.FIELD.getGenericType(containingClass, accessor) : accessType.getGenericType(containingClass, accessor);
         if (type == null) {
             return null;
         }

--- a/src/main/java/io/beanmapper/core/inspector/CombinedPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/CombinedPropertyAccessor.java
@@ -127,4 +127,13 @@ public class CombinedPropertyAccessor implements PropertyAccessor {
     public Method getWriteMethod() {
         return methodAccessor != null ? methodAccessor.getWriteMethod() : null;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <A extends Annotation> boolean isAnnotationPresent(Class<A> annotationClass) {
+        return (this.fieldAccessor != null && this.fieldAccessor.isAnnotationPresent(annotationClass))
+                || (this.methodAccessor != null && this.methodAccessor.isAnnotationPresent(annotationClass));
+    }
 }

--- a/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/FieldPropertyAccessor.java
@@ -70,7 +70,9 @@ public class FieldPropertyAccessor implements PropertyAccessor {
             if (instance instanceof Enum && field.getName().equals("name")) {
                 return ((Enum<?>) instance).name();
             }
-            field.setAccessible(true);
+            if (!field.canAccess(instance)) {
+                field.setAccessible(true);
+            }
             return field.get(instance);
         } catch (IllegalAccessException e) {
             throw new BeanPropertyReadException(instance.getClass(), field.getName(), e);
@@ -91,7 +93,9 @@ public class FieldPropertyAccessor implements PropertyAccessor {
     @Override
     public void setValue(Object instance, Object value) {
         try {
-            field.setAccessible(true);
+            if (!field.canAccess(instance)) {
+                field.setAccessible(true);
+            }
             field.set(instance, value);
         } catch (IllegalAccessException e) {
             throw new BeanPropertyWriteException(instance.getClass(), field.getName(), e);
@@ -102,8 +106,17 @@ public class FieldPropertyAccessor implements PropertyAccessor {
      * {@inheritDoc}
      */
     @Override
+    public <A extends Annotation> boolean isAnnotationPresent(final Class<A> annotationClass) {
+        return this.field.isAnnotationPresent(annotationClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Method getReadMethod() {
-        return null;
+        throw new UnsupportedOperationException("FieldPropertyAccessor#getReadMethod is not supported. If the "
+                + "read-method must be used to get the value of the field, use the MethodPropertyAccessor.");
     }
 
     /**
@@ -111,6 +124,7 @@ public class FieldPropertyAccessor implements PropertyAccessor {
      */
     @Override
     public Method getWriteMethod() {
-        return null;
+        throw new UnsupportedOperationException("FieldPropertyAccessor#getWriteMethod is not supported. If the "
+                + "write-method must be used to set the value of the field, use the MethodPropertyAccessor.");
     }
 }

--- a/src/main/java/io/beanmapper/core/inspector/MethodPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/MethodPropertyAccessor.java
@@ -75,7 +75,9 @@ public class MethodPropertyAccessor implements PropertyAccessor {
 
         try {
             Method readMethod = descriptor.getReadMethod();
-            readMethod.setAccessible(true);
+            if (!readMethod.canAccess(instance)) {
+                readMethod.setAccessible(true);
+            }
             return readMethod.invoke(instance);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new BeanPropertyReadException(instance.getClass(), getName(), e);
@@ -101,7 +103,9 @@ public class MethodPropertyAccessor implements PropertyAccessor {
 
         try {
             Method writeMethod = descriptor.getWriteMethod();
-            writeMethod.setAccessible(true);
+            if (!writeMethod.canAccess(instance)) {
+                writeMethod.setAccessible(true);
+            }
             writeMethod.invoke(instance, value);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new BeanPropertyWriteException(instance.getClass(), getName(), e);
@@ -123,4 +127,15 @@ public class MethodPropertyAccessor implements PropertyAccessor {
     public Method getWriteMethod() {
         return descriptor.getWriteMethod();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <A extends Annotation> boolean isAnnotationPresent(final Class<A> annotationClass) {
+        if (this.isReadable() && this.getReadMethod().isAnnotationPresent(annotationClass))
+            return true;
+        return this.isWritable() && this.getWriteMethod().isAnnotationPresent(annotationClass);
+    }
+
 }

--- a/src/main/java/io/beanmapper/core/inspector/PropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/PropertyAccessor.java
@@ -35,6 +35,15 @@ public interface PropertyAccessor {
     <A extends Annotation> A findAnnotation(Class<A> annotationClass);
 
     /**
+     * Checks whether the given annotation is present on a property.
+     *
+     * @param annotationClass Annotation-class
+     * @return True, if the annotation is present on the property, false otherwise.
+     * @param <A> The type of the annotation.
+     */
+    <A extends Annotation> boolean isAnnotationPresent(final Class<A> annotationClass);
+
+    /**
      * Determine if the property is readable.
      * @return {@code true} when readable, else {@code false}
      */

--- a/src/main/java/io/beanmapper/exceptions/BeanCollectionNotSupportedException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanCollectionNotSupportedException.java
@@ -5,7 +5,7 @@ public class BeanCollectionNotSupportedException extends BeanMappingException {
     public static final String ERROR = "The collection type combination %s | %s is not supported";
 
     public BeanCollectionNotSupportedException(Class<?> sourceClass, Class<?> targetClass) {
-        super(String.format(ERROR, sourceClass.getSimpleName(), targetClass.getSimpleName()));
+        super(ERROR.formatted(sourceClass.getSimpleName(), targetClass.getSimpleName()));
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanCollectionUnassignableTargetCollectionTypeException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanCollectionUnassignableTargetCollectionTypeException.java
@@ -5,6 +5,6 @@ public class BeanCollectionUnassignableTargetCollectionTypeException extends Bea
     public static final String ERROR = "Class %s is not assignable from %s.";
 
     public BeanCollectionUnassignableTargetCollectionTypeException(Class<?> staticClass, Class<?> dynamicClass) {
-        super(String.format(ERROR, staticClass.getSimpleName(), dynamicClass.getSimpleName()));
+        super(ERROR.formatted(staticClass.getSimpleName(), dynamicClass.getSimpleName()));
     }
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanConstructException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanConstructException.java
@@ -5,7 +5,7 @@ public class BeanConstructException extends BeanMappingException {
     public static final String ERROR = "No suitable constructor found while trying to bean construct class %s";
 
     public BeanConstructException(Class<?> classToInstantiate, Throwable rootCause) {
-        super(String.format(ERROR, classToInstantiate.getName()), rootCause);
+        super(ERROR.formatted(classToInstantiate.getName()), rootCause);
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanConversionException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanConversionException.java
@@ -14,7 +14,7 @@ public class BeanConversionException extends BeanMappingException {
     public static final String ERROR = "Could not convert %s to %s.";
 
     public BeanConversionException(Class<?> sourceClass, Class<?> targetClass) {
-        super(String.format(ERROR, sourceClass.getSimpleName(), targetClass.getSimpleName()));
+        super(ERROR.formatted(sourceClass.getSimpleName(), targetClass.getSimpleName()));
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanDynamicClassGenerationException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanDynamicClassGenerationException.java
@@ -5,7 +5,7 @@ public class BeanDynamicClassGenerationException extends RuntimeException {
     public static final String ERROR = "Error creating dynamic class for %s with key %s";
 
     public BeanDynamicClassGenerationException(Throwable rootCause, Class<?> baseClass, String key) {
-        super(String.format(ERROR, baseClass.getName(), key), rootCause);
+        super(ERROR.formatted(baseClass.getName(), key), rootCause);
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanInstantiationException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanInstantiationException.java
@@ -5,7 +5,7 @@ public class BeanInstantiationException extends BeanMappingException {
     public static final String ERROR = "Not possible to instantiate class %s";
 
     public BeanInstantiationException(Class<?> classToInstantiate, Throwable rootCause) {
-        super(String.format(ERROR, classToInstantiate.getName()), rootCause);
+        super(ERROR.formatted(classToInstantiate.getName()), rootCause);
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanMappingException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanMappingException.java
@@ -1,6 +1,6 @@
 package io.beanmapper.exceptions;
 
-public abstract class BeanMappingException extends RuntimeException {
+public abstract class BeanMappingException extends MappingException {
 
     protected BeanMappingException(String message) {
         super(message);

--- a/src/main/java/io/beanmapper/exceptions/BeanMissingPathException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanMissingPathException.java
@@ -5,7 +5,7 @@ public class BeanMissingPathException extends BeanMappingException {
     public static final String ERROR = "The path for the class could not be resolved %s.%s";
 
     public BeanMissingPathException(Class<?> clazz, String name, Throwable rootCause) {
-        super(String.format(ERROR, clazz.getName(), name), rootCause);
+        super(ERROR.formatted(clazz.getName(), name), rootCause);
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanPropertyNoMatchException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanPropertyNoMatchException.java
@@ -5,7 +5,7 @@ public class BeanPropertyNoMatchException extends BeanMappingException {
     public static final String ERROR = "No source field found while attempting to map to %s.%s";
 
     public BeanPropertyNoMatchException(Class<?> clazz, String fieldName) {
-        super(String.format(ERROR, clazz, fieldName));
+        super(ERROR.formatted(clazz, fieldName));
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanPropertyReadException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanPropertyReadException.java
@@ -9,7 +9,7 @@ public class BeanPropertyReadException extends BeanMappingException {
     }
 
     public BeanPropertyReadException(Class<?> classToInstantiate, String propertyName, Throwable rootCause) {
-        super(String.format(ERROR, classToInstantiate.getName(), propertyName), rootCause);
+        super(ERROR.formatted(classToInstantiate.getName(), propertyName), rootCause);
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/BeanPropertyWriteException.java
+++ b/src/main/java/io/beanmapper/exceptions/BeanPropertyWriteException.java
@@ -9,7 +9,7 @@ public class BeanPropertyWriteException extends BeanMappingException {
     }
 
     public BeanPropertyWriteException(Class<?> classToInstantiate, String propertyName, Throwable rootCause) {
-        super(String.format(ERROR, classToInstantiate.getName(), propertyName), rootCause);
+        super(ERROR.formatted(classToInstantiate.getName(), propertyName), rootCause);
     }
 
 }

--- a/src/main/java/io/beanmapper/exceptions/MappingException.java
+++ b/src/main/java/io/beanmapper/exceptions/MappingException.java
@@ -1,0 +1,13 @@
+package io.beanmapper.exceptions;
+
+public abstract class MappingException extends RuntimeException {
+
+    protected MappingException(final String message) {
+        super(message);
+    }
+
+    protected MappingException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/io/beanmapper/exceptions/RecordConstructorConflictException.java
+++ b/src/main/java/io/beanmapper/exceptions/RecordConstructorConflictException.java
@@ -1,0 +1,30 @@
+package io.beanmapper.exceptions;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.function.Supplier;
+
+public final class RecordConstructorConflictException extends RuntimeException {
+
+    public <T> RecordConstructorConflictException(final List<Constructor<T>> constructors) {
+        this(() -> {
+            StringBuilder builder = new StringBuilder("Record class ")
+                    .append(constructors.get(0).getDeclaringClass().getName())
+                    .append(" contains ")
+                    .append(constructors.size())
+                    .append(" constructors annotated with @RecordConstruct(String[], RecordConstructMode.FORCE).\n")
+                    .append("Signatures of offending constructors:\n");
+            for (var constructor : constructors) {
+                builder.append("\t- ")
+                        .append(constructor)
+                        .append("\n");
+            }
+            return builder.toString();
+        });
+    }
+
+    private RecordConstructorConflictException(final Supplier<String> messageSupplier) {
+        super(messageSupplier.get());
+    }
+
+}

--- a/src/main/java/io/beanmapper/exceptions/RecordConstructorNotFoundException.java
+++ b/src/main/java/io/beanmapper/exceptions/RecordConstructorNotFoundException.java
@@ -1,0 +1,8 @@
+package io.beanmapper.exceptions;
+
+public class RecordConstructorNotFoundException extends RuntimeException {
+
+    public <R extends Record> RecordConstructorNotFoundException(Class<R> recordClass, String message, Throwable cause) {
+        super("Constructor for record %s could not be found.%n%s".formatted(recordClass.getName(), message), cause);
+    }
+}

--- a/src/main/java/io/beanmapper/exceptions/RecordInstantiationException.java
+++ b/src/main/java/io/beanmapper/exceptions/RecordInstantiationException.java
@@ -1,0 +1,7 @@
+package io.beanmapper.exceptions;
+
+public class RecordInstantiationException extends RecordMappingException {
+    public RecordInstantiationException(Class<? extends Record> recordClass, Class<?> sourceClass, String message, Throwable cause) {
+        super(recordClass, sourceClass, message, cause);
+    }
+}

--- a/src/main/java/io/beanmapper/exceptions/RecordMappingException.java
+++ b/src/main/java/io/beanmapper/exceptions/RecordMappingException.java
@@ -1,0 +1,15 @@
+package io.beanmapper.exceptions;
+
+public abstract class RecordMappingException extends RuntimeException {
+
+    private static final String MESSAGE = "An error occurred while mapping to %s%s";
+
+    protected RecordMappingException(final Class<? extends Record> recordClass, final Class<?> sourceClass, final String message, final Throwable cause) {
+        super(MESSAGE.formatted(recordClass.getName(), "from %s.%n%s").formatted(sourceClass.getName(), message), cause);
+    }
+
+    protected RecordMappingException(final Class<? extends Record> recordClass, final String message) {
+        super(MESSAGE.formatted(recordClass.getName(), ": %s".formatted(message)));
+    }
+
+}

--- a/src/main/java/io/beanmapper/exceptions/RecordMappingToIntermediaryException.java
+++ b/src/main/java/io/beanmapper/exceptions/RecordMappingToIntermediaryException.java
@@ -1,0 +1,10 @@
+package io.beanmapper.exceptions;
+
+public class RecordMappingToIntermediaryException extends RuntimeException {
+
+    public RecordMappingToIntermediaryException(Class<?> sourceClass, Throwable cause) {
+        super("Record %s could not be mapped to intermediary-class. %s".formatted(sourceClass.getName(),
+                cause.getMessage()), cause);
+    }
+
+}

--- a/src/main/java/io/beanmapper/exceptions/RecordNoAvailableConstructorsExceptions.java
+++ b/src/main/java/io/beanmapper/exceptions/RecordNoAvailableConstructorsExceptions.java
@@ -1,0 +1,7 @@
+package io.beanmapper.exceptions;
+
+public class RecordNoAvailableConstructorsExceptions extends RecordMappingException {
+    public RecordNoAvailableConstructorsExceptions(Class<? extends Record> recordClass, String message) {
+        super(recordClass, message);
+    }
+}

--- a/src/main/java/io/beanmapper/exceptions/SourceFieldAccessException.java
+++ b/src/main/java/io/beanmapper/exceptions/SourceFieldAccessException.java
@@ -1,0 +1,7 @@
+package io.beanmapper.exceptions;
+
+public class SourceFieldAccessException extends RecordMappingException {
+    public SourceFieldAccessException(Class<? extends Record> recordClass, Class<?> sourceClass, String message, Throwable cause) {
+        super(recordClass, sourceClass, message, cause);
+    }
+}

--- a/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
@@ -10,9 +10,9 @@ import io.beanmapper.config.Configuration;
 import io.beanmapper.core.BeanMatch;
 import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.converter.BeanConverter;
-import io.beanmapper.core.converter.collections.CollectionConverter;
 import io.beanmapper.exceptions.BeanConversionException;
 import io.beanmapper.exceptions.BeanPropertyNoMatchException;
+import io.beanmapper.utils.Records;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,13 +41,28 @@ public abstract class AbstractMapStrategy implements MapStrategy {
         return beanMapper;
     }
 
+    /**
+     * Composes the {@link ConstructorArguments}-object for the given source and {@link BeanMatch}-object.
+     *
+     * <p>This method is used specifically by the {@link MapToClassStrategy} and the {@link MapToRecordStrategy}.</p><p>The source-class is checked for the
+     * presence of the {@link BeanConstruct}-annotation. If the annotation is present, the names of the fields described by the annotation will be stored in the
+     * values-array of the method. <p>If no BeanConstruct-annotation is present, a check will be performed to see if the target-class is a record. If so, the
+     * values-array will be set to the result of the {@link Records#getRecordFieldNames(Class)}-method, which essentially loops through all the
+     * RecordComponent-objects associated with the target-class, and returns an array of their names.</p><p>Lastly, if the values-array is null, null will
+     * be returned. Otherwise, a new ConstructorArguments-object will be returned, using the source-object, the BeanMatch, and the values-array.</p>
+     *
+     * @param source The source-object that will be mapped to the target.
+     * @param beanMatch The BeanMatch that will be used to map the source to the target.
+     * @return ConstructorArguments-object constructed from the source, beanMatch and values taken from either the BeanConstruct-annotation, or
+     *         RecordComponents.
+     * @param <S> The type of the source-object.
+     */
     public <S> ConstructorArguments getConstructorArguments(S source, BeanMatch beanMatch) {
-        BeanConstruct beanConstruct = beanMatch.getTargetClass().getAnnotation(BeanConstruct.class);
+        final Class<?> targetClass = beanMatch.getTargetClass();
 
-        // If the target does not have a BeanConstruct annotation, check the source
-        if (beanConstruct == null) {
-            beanConstruct = beanMatch.getSourceClass().getAnnotation(BeanConstruct.class);
-        }
+        BeanConstruct beanConstruct = targetClass.isAnnotationPresent(BeanConstruct.class)
+                ? targetClass.getAnnotation(BeanConstruct.class)
+                : beanMatch.getSourceClass().getAnnotation(BeanConstruct.class);
 
         // If no BeanConstruct exists, assume a no-arg constructor must be used
         return beanConstruct == null ? null : new ConstructorArguments(source, beanMatch, beanConstruct.value());
@@ -123,11 +138,6 @@ public abstract class AbstractMapStrategy implements MapStrategy {
         Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(beanPropertyMatch.getSourceClass());
         BeanConverter converter = getConverterOptional(valueClass, targetClass);
 
-        // @TODO Consider removing the null check here and offering a null value to BeanConverters as well
-        if (value == null && !(converter instanceof CollectionConverter)) {
-            return null;
-        }
-
         if (converter != null) {
             logger.debug("{}{}{}", INDENT, converter.getClass().getSimpleName(), ARROW);
             BeanMapper wrappedBeanMapper = beanMapper
@@ -135,6 +145,10 @@ public abstract class AbstractMapStrategy implements MapStrategy {
                     .setParent(beanPropertyMatch.getTarget())
                     .build();
             return converter.convert(wrappedBeanMapper, value, targetClass, beanPropertyMatch);
+        }
+
+        if (value == null) {
+            return this.configuration.getDefaultValueForClass(targetClass);
         }
 
         if (targetClass.isAssignableFrom(valueClass)) {

--- a/src/main/java/io/beanmapper/strategy/ConstructorArguments.java
+++ b/src/main/java/io/beanmapper/strategy/ConstructorArguments.java
@@ -13,6 +13,8 @@ public class ConstructorArguments {
     private List<Object> values = new ArrayList<>();
 
     public ConstructorArguments(Object source, BeanMatch beanMatch, String[] constructorArgs) {
+        if (constructorArgs == null)
+            throw new IllegalArgumentException("Cannot construct ConstructorArguments-object: Constructor-parameter String[] constructorArgs is null.");
 
         for (String constructorArg : constructorArgs) {
             if (constructorArgumentFoundInSource(beanMatch, constructorArg)) {

--- a/src/main/java/io/beanmapper/strategy/MapCollectionStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapCollectionStrategy.java
@@ -12,7 +12,7 @@ public class MapCollectionStrategy extends AbstractMapStrategy {
     }
 
     @Override
-    public Object map(Object source) {
+    public <S, T> T map(S source) {
 
         CollectionHandler collectionHandler = getConfiguration().getCollectionHandlerForCollectionClass();
 
@@ -26,10 +26,10 @@ public class MapCollectionStrategy extends AbstractMapStrategy {
         );
 
         if (source == null) {
-            return targetItems;
+            return (T) targetItems;
         }
 
-        return collectionHandler.copy(
+        return (T) collectionHandler.copy(
                 getBeanMapper(),
                 getConfiguration().getTargetClass(),
                 source,

--- a/src/main/java/io/beanmapper/strategy/MapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapStrategy.java
@@ -2,6 +2,6 @@ package io.beanmapper.strategy;
 
 public interface MapStrategy {
 
-    Object map(Object source);
+    <S, T> T map(S source);
 
 }

--- a/src/main/java/io/beanmapper/strategy/MapStrategyType.java
+++ b/src/main/java/io/beanmapper/strategy/MapStrategyType.java
@@ -23,6 +23,12 @@ public enum MapStrategyType {
             return new MapToClassStrategy(beanMapper, configuration);
         }
     },
+    MAP_TO_RECORD() {
+        @Override
+        public MapStrategy generateMapStrategy(BeanMapper beanMapper, Configuration configuration) {
+            return new MapToRecordStrategy(beanMapper, configuration);
+        }
+    },
     MAP_TO_INSTANCE() {
         @Override
         public MapStrategy generateMapStrategy(BeanMapper beanMapper, Configuration configuration) {
@@ -40,7 +46,7 @@ public enum MapStrategyType {
         } else if (configuration.getCollectionClass() != null) {
             return MAP_COLLECTION;
         } else if (configuration.getTargetClass() != null) {
-            return MAP_TO_CLASS;
+            return configuration.getTargetClass().isRecord() ? MAP_TO_RECORD : MAP_TO_CLASS;
         } else if (configuration.getTarget() != null) {
             return MAP_TO_INSTANCE;
         } else {

--- a/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
@@ -12,15 +12,16 @@ public class MapToClassStrategy extends MapToInstanceStrategy {
     }
 
     @Override
-    public Object map(Object source) {
+    public <S, T> T map(S source) {
         Class<?> targetClass = getConfiguration().getTargetClass();
 
-        if (getConfiguration().isConverterChoosable()) {
+        if (getConfiguration().isConverterChoosable() || source instanceof Record) {
             Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(source.getClass());
             BeanConverter converter = getConverterOptional(valueClass, targetClass);
             if (converter != null) {
-                logger.debug("    {}->", converter.getClass().getSimpleName());
-                return converter.convert(getBeanMapper(), source, targetClass, null);
+                logger.debug("Converter called for source of class {}, while mapping to class {}\t{}->", source.getClass(), targetClass,
+                        converter.getClass().getSimpleName());
+                return (T) converter.convert(getBeanMapper(), source, targetClass, null);
             }
         }
 
@@ -29,6 +30,6 @@ public class MapToClassStrategy extends MapToInstanceStrategy {
                 targetClass,
                 getConstructorArguments(source, beanMatch));
 
-        return map(source, target, beanMatch);
+        return (T) map(source, target, beanMatch);
     }
 }

--- a/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
@@ -13,7 +13,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
     }
 
     @Override
-    public Object map(Object source) {
+    public <S, T> T map(S source) {
         List<String> downsizeSourceFields = getConfiguration().getDownsizeSource();
         List<String> downsizeTargetFields = getConfiguration().getDownsizeTarget();
 
@@ -28,7 +28,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
         } else if (downsizeTargetFields != null && !downsizeTargetFields.isEmpty()) {
             return downsizeTarget(source, downsizeTargetFields);
         } else {
-            // Force re-entry through the core map method, but disregard the include fields now
+            // Force re-entry through the core map method, but disregard the include-fields now
             return getBeanMapper()
                     .wrap()
                     .downsizeSource(null)
@@ -38,7 +38,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
         }
     }
 
-    public Object downsizeSource(Object source, List<String> downsizeSourceFields) {
+    public <S, T> T downsizeSource(S source, List<String> downsizeSourceFields) {
         final Class<?> dynamicClass = getConfiguration()
                 .getClassStore()
                 .getOrCreateGeneratedClass(
@@ -65,7 +65,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
                 .map(dynSource);
     }
 
-    public Object downsizeTarget(Object source, List<String> downsizeTargetFields) {
+    public <S, T> T downsizeTarget(S source, List<String> downsizeTargetFields) {
         final Class<?> dynamicClass = getConfiguration().getClassStore().getOrCreateGeneratedClass(
                 getConfiguration().determineTargetClass(),
                 downsizeTargetFields,

--- a/src/main/java/io/beanmapper/strategy/MapToInstanceStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToInstanceStrategy.java
@@ -11,15 +11,15 @@ public class MapToInstanceStrategy extends AbstractMapStrategy {
     }
 
     @Override
-    public Object map(Object source) {
-        return map(source, getConfiguration().getTarget());
+    public <S, T> T map(S source) {
+        return (T) map(source, getConfiguration().getTarget());
     }
 
-    protected Object map(Object source, Object target) {
+    protected <S, T> T map(S source, T target) {
         return map(source, target, getBeanMatch(source.getClass(), target.getClass()));
     }
 
-    protected Object map(Object source, Object target, BeanMatch beanMatch) {
+    protected <S, T> T map(S source, T target, BeanMatch beanMatch) {
         return processProperties(source, target, beanMatch);
     }
 }

--- a/src/main/java/io/beanmapper/strategy/MapToRecordStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToRecordStrategy.java
@@ -1,0 +1,253 @@
+package io.beanmapper.strategy;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.annotations.BeanAlias;
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+import io.beanmapper.config.Configuration;
+import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.exceptions.BeanInstantiationException;
+import io.beanmapper.exceptions.RecordConstructorConflictException;
+import io.beanmapper.exceptions.RecordNoAvailableConstructorsExceptions;
+import io.beanmapper.exceptions.SourceFieldAccessException;
+import io.beanmapper.utils.Records;
+
+/**
+ * MapToRecordStrategy offers a comprehensive implementation of the MapToClassStrategy, targeted towards mapping a class
+ * to a record.
+ *
+ * <p>A class (or record) can be mapped to a target record, simply by calling the map-method associated with this class.
+ * </p><p>Internally, the map-method will create dynamic classes as needed, to create suitable intermediaries. At least
+ * one, and at most two, intermediary classed can be generated. For class-generation, the
+ * {@link io.beanmapper.dynclass.ClassGenerator}-class is used.</p>
+ */
+public final class MapToRecordStrategy extends MapToClassStrategy {
+
+    MapToRecordStrategy(BeanMapper beanMapper, Configuration configuration) {
+        super(beanMapper, configuration);
+    }
+
+    @Override
+    public <S, T> T map(final S source) {
+
+        Class<T> targetClass = this.getConfiguration().getTargetClass();
+
+        if (source.getClass().equals(targetClass))
+            return targetClass.cast(source);
+
+        // We use the RecordToAny-converter in case the source is also a Record. Furthermore, allowing the use of custom
+        // converters increases flexibility of the library.
+        if (getConfiguration().isConverterChoosable()) {
+            BeanConverter converter = getConverterOptional(source.getClass(), this.getConfiguration().getTargetClass());
+            if (converter != null) {
+                if (logger.isDebugEnabled())
+                    logger.debug("Converter called for source of class {}, while mapping to class {}\t{}->", source.getClass(), targetClass,
+                            converter.getClass().getSimpleName());
+                return converter.convert(getBeanMapper(), source, targetClass, null);
+            }
+        }
+
+        Map<String, Field> sourceFields = getSourceFields(source);
+        Constructor<T> constructor = (Constructor<T>) getSuitableConstructor(sourceFields, targetClass);
+        String[] fieldNamesForConstructor = getNamesOfConstructorParameters(targetClass, constructor);
+        List<Object> values = getValuesOfFields(source, sourceFields, sourceFields, Arrays.stream(fieldNamesForConstructor));
+
+        return targetClass.cast(constructTargetObject(constructor, values));
+    }
+
+    /**
+     * Gets a Map&lt;String, Field&gt;, containing the fields of the class, mapped by the name of the field, or the value of the BeanAlias-annotation if it is
+     * present.
+     *
+     * @param sourceClass The class of the source-object.
+     * @return A Map containing the fields of the source-class, mapped by the name of the field, or the value of an available BeanAlias.
+     * @param <S> The type of the sourceClass.
+     */
+    private <S> Map<String, Field> getFieldsOfClass(final Class<S> sourceClass) {
+        return Arrays.stream(sourceClass.getDeclaredFields())
+                .map(field -> {
+                    if (field.isAnnotationPresent(BeanAlias.class)) {
+                        return Map.entry(field.getAnnotation(BeanAlias.class).value(), field);
+                    }
+                    return Map.entry(field.getName(), field);
+                })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Gets the fields in the source-object, mapped to their name, or, if present, the value of the
+     * BeanAlias-annotation.
+     *
+     * @param source The source-object, of which the fields will be mapped.
+     * @return The fields of the source-object, mapped to the
+     * @param <S>
+     */
+    private <S> Map<String, Field> getSourceFields(final S source) {
+        Map<String, Field> sourceFields = new HashMap<>();
+        Class<? super S> sourceClass = (Class<? super S>) source.getClass();
+        while (!sourceClass.equals(Object.class)) {
+            sourceFields.putAll(getFieldsOfClass(sourceClass));
+            sourceClass = sourceClass.getSuperclass();
+        }
+        return sourceFields;
+    }
+
+    /**
+     * Gets the names of the RecordComponents as a String-array.
+     *
+     * <p>The names of the RecordComponents are retrieved either from the {@link RecordComponent#getName()}-method, or
+     * from an available {@link io.beanmapper.annotations.BeanProperty BeanProperty}-annotation.</p>
+     *
+     * @param targetClass The class of the target record.
+     * @return The names of the RecordComponents as a String-array.
+     * @param <T> The type of the target record.
+     */
+    private <T> String[] getNamesOfRecordComponents(final Class<T> targetClass) {
+        return Arrays.stream(targetClass.getRecordComponents())
+                .map(recordComponent -> {
+                    if (recordComponent.isAnnotationPresent(io.beanmapper.annotations.BeanProperty.class)) {
+                        return recordComponent.getAnnotation(io.beanmapper.annotations.BeanProperty.class).value();
+                    }
+                    return recordComponent.getName();
+                })
+                .toArray(String[]::new);
+    }
+
+    /**
+     * Gets the names of constructor parameters.
+     *
+     * <p>Prefers to use the RecordConstruct-annotation, if it is present. Otherwise, it will use the RecordComponents of the record, to determine the names and
+     * order of the parameters.</p>
+     *
+     * @param targetClass The target record.
+     * @param constructor The target constructor.
+     * @return The String-array containing the names of the constructor-parameters.
+     * @param <T> The type of the target class.
+     */
+    private <T> String[] getNamesOfConstructorParameters(final Class<T> targetClass, final Constructor<T> constructor) {
+        if (constructor.isAnnotationPresent(RecordConstruct.class)) {
+            return constructor.getAnnotation(RecordConstruct.class).value();
+        }
+
+        // We can only use this in cases where the compiler added the parameter-name to the classfile. If the name is
+        // present, we use the parameter-names, otherwise we use the names as set in the record-components.
+        var parameters = constructor.getParameters();
+        if (constructor.getParameters()[0].isNamePresent()) {
+            return Arrays.stream(parameters)
+                    .map(Parameter::getName)
+                    .toArray(String[]::new);
+        }
+        return getNamesOfRecordComponents(targetClass);
+    }
+
+    private <S> List<Object> getValuesOfFields(final S source, final Map<String, Field> sourceFields, final Map<String, Field> fieldMap,
+            final Stream<String> fieldNamesForConstructor) {
+        return fieldNamesForConstructor.map(fieldName -> {
+                    Field field = fieldMap.get(fieldName);
+                    if (field != null) {
+                        return field;
+                    }
+                    return sourceFields.get(fieldName);
+                }).map(field -> getValueFromField(source, field))
+                .toList();
+    }
+
+    private Object[] getConstructorArgumentsMappedToCorrectTargetType(final Parameter[] parameters, final List<Object> values) {
+        Object[] arguments = new Object[parameters.length];
+        for (var i = 0; i < parameters.length; ++i) {
+            if (i >= values.size() || values.get(i) == null) {
+                arguments[i] = this.getConfiguration().getDefaultValueForClass(parameters[i].getType());
+            } else {
+                var parameterType = parameters[i].getType();
+                if (Collection.class.isAssignableFrom(parameterType) || Optional.class.isAssignableFrom(parameterType)
+                        || Map.class.isAssignableFrom(parameterType)) {
+                    arguments[i] = this.getBeanMapper().map(values.get(i), (ParameterizedType) parameters[i].getParameterizedType());
+                } else {
+                    arguments[i] = values.get(i) != null && parameters[i].getType().equals(values.get(i).getClass()) ?
+                            values.get(i) :
+                            this.getBeanMapper().wrap().setConverterChoosable(true).build().map(values.get(i), parameterType);
+                }
+            }
+        }
+        return arguments;
+    }
+
+    private <T> T constructTargetObject(final Constructor<T> targetConstructor, final List<Object> values) {
+        try {
+            return targetConstructor.newInstance(getConstructorArgumentsMappedToCorrectTargetType(targetConstructor.getParameters(), values));
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new BeanInstantiationException(targetConstructor.getDeclaringClass(), e);
+        }
+    }
+
+    private <S> Object getValueFromField(final S source, final Field field) {
+        if (field == null) {
+            return null;
+        }
+        try {
+            if (!field.canAccess(source))
+                field.setAccessible(true);
+            return field.get(source);
+        } catch (IllegalAccessException ex) {
+            throw new SourceFieldAccessException(this.getConfiguration().getTargetClass(), source.getClass(), "Could not access field " + field.getName(), ex);
+        }
+    }
+
+    private <T> Constructor<?> getSuitableConstructor(final Map<String, Field> sourceFields, final Class<T> targetClass) {
+        List<Constructor<T>> constructors = new ArrayList<>(Records.getConstructorsAnnotatedWithRecordConstruct(targetClass));
+        List<Constructor<T>> mandatoryConstructor = constructors.stream()
+                .filter(constructor -> constructor.getAnnotation(RecordConstruct.class).constructMode() == RecordConstructMode.FORCE)
+                .toList();
+        if (!mandatoryConstructor.isEmpty()) {
+            if (mandatoryConstructor.size() > 1) {
+                throw new RecordConstructorConflictException(constructors);
+            }
+            return mandatoryConstructor.get(0);
+        }
+        if (!constructors.isEmpty()) {
+            // Once we get to this point, the constructors-list can only contain constructors with the
+            // RecordConstructMode.ON_DEMAND-option.
+            // Sorts the list in reverse, to make constructor with the most arguments the first to be considered.
+            constructors.sort((arg0, arg1) -> Integer.compare(arg1.getParameterCount(), arg0.getParameterCount()));
+            return getConstructorWithMostMatchingParameters(constructors, sourceFields).orElse(Records.getCanonicalConstructorOfRecord((Class) targetClass));
+        }
+        var canonicalConstructor = Records.getCanonicalConstructorOfRecord((Class) targetClass);
+        if (canonicalConstructor.isAnnotationPresent(RecordConstruct.class)) {
+            var recordConstruct = (RecordConstruct) canonicalConstructor.getAnnotation(RecordConstruct.class);
+            if (recordConstruct.constructMode() == RecordConstructMode.EXCLUDE)
+                throw new RecordNoAvailableConstructorsExceptions((Class<? extends Record>) targetClass, "All available constructors have been "
+                        + "annotated with @RecordConstruct(constructMode = RecordConstructMode.EXCLUDE). To enable mapping to the target record, please make at "
+                        + "least one constructor available.");
+        }
+        return canonicalConstructor;
+    }
+
+    private <T> Optional<Constructor<T>> getConstructorWithMostMatchingParameters(final List<Constructor<T>> constructors,
+            final Map<String, Field> sourceFields) {
+        for (var constructor : constructors) {
+            RecordConstruct recordConstruct = constructor.getAnnotation(RecordConstruct.class);
+            List<Field> relevantFields = Arrays.stream(recordConstruct.value())
+                    .map(sourceFields::get)
+                    .toList();
+            if (!relevantFields.contains(null) || recordConstruct.allowNull())
+                return Optional.of(constructor);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/beanmapper/utils/DefaultValues.java
+++ b/src/main/java/io/beanmapper/utils/DefaultValues.java
@@ -1,17 +1,28 @@
 package io.beanmapper.utils;
 
+import static java.util.Map.entry;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class DefaultValues {
 
-    private static final Map<Class<?>, Object> defaultValues = Map.of(
-            boolean.class, false,
-            byte.class, (byte) 0,
-            short.class, (short) 0,
-            int.class, 0,
-            char.class, '\0',
-            float.class, 0.0F,
-            double.class, 0.0
+    private static final Map<Class<?>, Object> defaultValues = Map.ofEntries(
+            entry(boolean.class, false),
+            entry(byte.class, (byte) 0),
+            entry(short.class, (short) 0),
+            entry(int.class, 0),
+            entry(long.class, 0L),
+            entry(char.class, '\0'),
+            entry(float.class, 0.0F),
+            entry(double.class, 0.0),
+            entry(Optional.class, Optional.empty()),
+            entry(List.class, Collections.emptyList()),
+            entry(Set.class, Collections.emptySet()),
+            entry(Map.class, Collections.emptyMap())
     );
 
     /**
@@ -21,7 +32,7 @@ public class DefaultValues {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> T defaultValueFor(Class<T> clazz) {
-        return (T) defaultValues.get(clazz);
+    public static <T, V> V defaultValueFor(Class<T> clazz) {
+        return (V) defaultValues.get(clazz);
     }
 }

--- a/src/main/java/io/beanmapper/utils/Records.java
+++ b/src/main/java/io/beanmapper/utils/Records.java
@@ -1,0 +1,82 @@
+package io.beanmapper.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+import io.beanmapper.exceptions.RecordConstructorNotFoundException;
+
+/**
+ * <p>Utility-class for methods commonly used when mapping to and from records.</p>
+ */
+public final class Records {
+
+    private Records() {
+    }
+
+    /**
+     * <p>Gets the names of all the fields that are passed to the given record through the constructor.</p>
+     * <p>By using the names of {@link java.lang.reflect.RecordComponent}-objects, this method won't map any of the
+     * static fields a record may contain.</p>
+     *
+     * @param clazz The record of which the names of the RecordComponent-objects will be returned.
+     * @return An array containing the names of the RecordComponent-objects.
+     */
+    public static String[] getRecordFieldNames(Class<? extends Record> clazz) {
+        String[] values = new String[clazz.getRecordComponents().length];
+        var recordComponents = clazz.getRecordComponents();
+        for (var i = 0; i < recordComponents.length; ++i) {
+            values[i] = recordComponents[i].getName();
+        }
+        return values;
+    }
+
+    /**
+     * Gets the canonical constructor of the given record.
+     *
+     * <p>The canonical constructor is the constructor in a record, that is automatically generated based off of the
+     * signature of the record. A canonical constructor requires every RecordComponent as its parameter, in the order
+     * they were declared in.</p>
+     * <p>Based off of the requirements for a canonical constructor, we can retrieve the canonical constructor by
+     * creating an array of the types of the RecordComponents, in the correct order, and calling
+     * {@link Class#getDeclaredConstructor(Class[])}</p>
+     *
+     * @param recordClass The type of the record.
+     * @return The canonical constructor of the record.
+     * @param <R> The type of the record.
+     */
+    public static <R extends Record> Constructor<R> getCanonicalConstructorOfRecord(Class<R> recordClass) {
+        Class<?>[] componentTypes = Arrays.stream(recordClass.getRecordComponents())
+                .map(RecordComponent::getType)
+                .toArray(Class<?>[]::new);
+        try {
+            return recordClass.getDeclaredConstructor(componentTypes);
+        } catch (NoSuchMethodException e) {
+            StringBuilder builder = new StringBuilder();
+            for (var type : componentTypes) {
+                builder.append(type.getName()).append(", ");
+            }
+            throw new RecordConstructorNotFoundException(recordClass,
+                    "Attempted to get constructor with signature: %s(%s)".formatted(
+                            recordClass.getName(), builder.substring(0, builder.length() - 1)), e);
+        }
+    }
+
+    /**
+     * Gets all constructors of the target record, annotated with {@link RecordConstruct @RecordConstruct}, without the option
+     * constructMode = {@link RecordConstructMode#EXCLUDE}.
+     * @param recordClass The record-class of which the constructors will be retrieved.
+     * @return The collection of constructors annotated with the @RecordConstruct-annotation.
+     * @param <R> The type of the record-class.
+     */
+    public static <R> Collection<Constructor<R>> getConstructorsAnnotatedWithRecordConstruct(Class<R> recordClass) {
+        return Arrays.stream(recordClass.getConstructors())
+                .filter(constructor -> constructor.isAnnotationPresent(RecordConstruct.class)
+                        && constructor.getAnnotation(RecordConstruct.class).constructMode() != RecordConstructMode.EXCLUDE)
+                .map(constructor -> (Constructor<R>) constructor)
+                .toList();
+    }
+}

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -96,7 +96,9 @@ import io.beanmapper.testmodel.collections.target_is_wrapped.UnwrappedSource;
 import io.beanmapper.testmodel.collections.target_is_wrapped.UnwrappedToWrappedBeanConverter;
 import io.beanmapper.testmodel.collections.target_is_wrapped.WrappedTarget;
 import io.beanmapper.testmodel.construct.NestedSourceWithoutConstruct;
+import io.beanmapper.testmodel.construct.SourceBeanConstructWithList;
 import io.beanmapper.testmodel.construct.SourceWithConstruct;
+import io.beanmapper.testmodel.construct.TargetBeanConstructWithList;
 import io.beanmapper.testmodel.construct.TargetWithoutConstruct;
 import io.beanmapper.testmodel.construct_not_matching.BigConstructTarget;
 import io.beanmapper.testmodel.construct_not_matching.BigConstructTarget2;
@@ -1865,6 +1867,14 @@ class BeanMapperTest {
         assertEquals(personFormArray[0].getId(), resultArray[0].getId());
         assertEquals(personFormArray[1].getId(), resultArray[1].getId());
         assertEquals(personFormArray[2].getId(), resultArray[2].getId());
+    }
+
+    @Test
+    void testBeanConstructWithCollectionShouldConvertCollectionItems() {
+        var form = new SourceBeanConstructWithList();
+        var result = this.beanMapper.map(form, TargetBeanConstructWithList.class);
+        assertEquals(form.numbers.size(), result.getNumbers().size());
+        assertTrue(result.getNumbers().containsAll(List.of(1, 2, 3)));
     }
 
     private MyEntity createMyEntity() {

--- a/src/test/java/io/beanmapper/config/OverrideConfigurationTest.java
+++ b/src/test/java/io/beanmapper/config/OverrideConfigurationTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Queue;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.core.constructor.DefaultBeanInitializer;
@@ -42,6 +44,9 @@ public class OverrideConfigurationTest {
         assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addPackagePrefix((Class) null));
         assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addAfterClearFlusher(null));
         assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.setBeanUnproxy(null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.setRoleSecuredCheck(null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addCollectionHandler(null));
+        assertThrows(BeanConfigurationOperationNotAllowedException.class, () -> overrideConfiguration.addLogicSecuredCheck(null));
     }
 
     @Test
@@ -113,6 +118,24 @@ public class OverrideConfigurationTest {
     void determineTargetClass() {
         overrideConfiguration.setTarget("Hello");
         assertEquals(String.class, overrideConfiguration.determineTargetClass());
+    }
+
+    @Test
+    void testAddCustomDefaultValueForQueue() {
+        overrideConfiguration.addCustomDefaultValueForClass(Queue.class, new ArrayDeque<>());
+        assertEquals(ArrayDeque.class, this.overrideConfiguration.getDefaultValueForClass(Queue.class).getClass());
+    }
+
+    @Test
+    void testSetEnforceSecuredProperties_true() {
+        overrideConfiguration.setEnforceSecuredProperties(true);
+        assertTrue(overrideConfiguration.getEnforceSecuredProperties());
+    }
+
+    @Test
+    void testSetEnforceSecuredProperties_false() {
+        overrideConfiguration.setEnforceSecuredProperties(false);
+        assertFalse(overrideConfiguration.getEnforceSecuredProperties());
     }
 
 }

--- a/src/test/java/io/beanmapper/config/OverrideFieldTest.java
+++ b/src/test/java/io/beanmapper/config/OverrideFieldTest.java
@@ -1,6 +1,9 @@
 package io.beanmapper.config;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +18,15 @@ class OverrideFieldTest {
 
     private String get() {
         return "Hello world!";
+    }
+
+    @Test
+    void testBlockIsTrueAfterPassingNull() throws NoSuchFieldException, IllegalAccessException {
+        OverrideField<String> text = new OverrideField<>(this::get);
+        text.set(null);
+        Field blockField = text.getClass().getDeclaredField("block");
+        blockField.setAccessible(true);
+        assertTrue((Boolean) blockField.get(text));
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/RecordToAnyConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/RecordToAnyConverterTest.java
@@ -1,0 +1,30 @@
+package io.beanmapper.core.converter.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.testmodel.record.PersonRecordWithNestedRecord;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecordToAnyConverterTest {
+
+    private RecordToAnyConverter converter;
+
+    @BeforeEach
+    public void setUp() {
+        this.converter = new RecordToAnyConverter();
+    }
+
+    @Test
+    void isMatchTrueIfSourceIsRecord() {
+        assertTrue(converter.match(PersonRecordWithNestedRecord.class, Object.class));
+    }
+
+    @Test
+    void isMatchFalseIfSourceIsNotRecord() {
+        assertFalse(converter.match(Object.class, Object.class));
+    }
+
+}

--- a/src/test/java/io/beanmapper/shared/AssertionUtils.java
+++ b/src/test/java/io/beanmapper/shared/AssertionUtils.java
@@ -1,0 +1,98 @@
+package io.beanmapper.shared;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Field;
+
+/**
+ * A collection of methods that can be used to perform frequently used, and often verbose, tests.
+ */
+public final class AssertionUtils {
+
+    /**
+     * Private constructor, used to hide the default public constructor.
+     */
+    private AssertionUtils() {
+    }
+
+    /**
+     * Asserts that the given class contains a field with the given name, and returns the corresponding Field-object.
+     *
+     * @param clazz The class that should contain a field with the given field-name.
+     * @param fieldName The name of the field that should be contained within the given class.
+     * @return If the assertion succeeds, this method returns the Field-object declared by the given class, with the
+     *         given field-name.
+     * @param <T> The type of the class that should contain a field with the given name.
+     */
+    public static <T> Field assertClassContainsField(final Class<T> clazz, final String fieldName) {
+        return assertDoesNotThrow(() -> clazz.getDeclaredField(fieldName));
+    }
+
+    /**
+     * Asserts that the class of the given instance contains a field with the given name.
+     *
+     * <p>This method utilises the {@link AssertionUtils#assertClassContainsField(Class, String)}-method. Calling
+     * this method is equivalent to calling
+     * {@code AssertionUtils.assertClassContainsField(instance.getClass(), fieldName);}</p>
+     *
+     * @param instance The instance, of which the class should contain a field with the given name.
+     * @param fieldName The name of the field that should be present in the class of the given instance.
+     * @return The Field-object with the given name, contained within the class of the given instance.
+     * @param <T> The type of the instance.
+     */
+    public static <T> Field assertInstanceContainsField(final T instance, final String fieldName) {
+        return assertClassContainsField(instance.getClass(), fieldName);
+    }
+
+    /**
+     * Asserts that the given class does not contain a field with the given name, and returns the NoSuchFieldException,
+     * that should be returned by the assertion.
+     *
+     * @param clazz The class that should not contain a field with the given name.
+     * @param fieldName The field-name that should not be present in the given class.
+     * @return The NoSuchFieldException that should be returned by the assertion.
+     * @param <T> The type of the class that should not contain a field with the given name.
+     */
+    public static <T> NoSuchFieldException assertClassDoesNotContainField(final Class<T> clazz, final String fieldName) {
+        return assertThrows(NoSuchFieldException.class, () -> clazz.getDeclaredField(fieldName));
+    }
+
+    /**
+     * Asserts that the class of the given instance does not contain a field with the given name.
+     *
+     * <p>This method utilises the {@link AssertionUtils#assertClassDoesNotContainField(Class, String)}-method. Calling
+     * this method is equivalent to calling
+     * <code>AssertionUtils.assertClassDoesNotContainField(instance.getClass(), fieldName);</code></p>
+     *
+     * @param instance The instance, of which the class should not contain a field with the given name.
+     * @param fieldName The name that should not correspond to a field in the class of the given instance.
+     * @return The NoSuchFieldException that should be returned by the assertion.
+     * @param <T> The type of the instance.
+     */
+    public static <T> NoSuchFieldException assertInstanceDoesNotContainField(final T instance, final String fieldName) {
+        return assertClassDoesNotContainField(instance.getClass(), fieldName);
+    }
+
+    /**
+     * Asserts that the given instance contains a field with the given name, of which the value equals the given value.
+     *
+     * <p>This method utilises the {@link ReflectionUtils#getFieldWithName(Class, String)}-method to get the field in
+     * the class of the given instance, with the name corresponding to the given name.</p><p>Additionally, it utilises
+     * the {@link ReflectionUtils#getValueOfField(Object, Field)}-method to get the value of the field retrieved by the
+     * aforementioned ReflectionUtils#getFieldWithName(Class, String)-method.</p><p>Lastly, the method asserts that the
+     * value retrieved by the aforementioned ReflectionUtils#getValueOfField(Object, Field)-method equals the value
+     * passed to this method.</p>
+     *
+     * @param instance
+     * @param fieldName
+     * @param value
+     * @param <T>
+     * @param <V>
+     */
+    public static <T, V> void assertFieldWithNameHasValue(final T instance, final String fieldName, final V value) {
+        assertEquals(value, ReflectionUtils.getValueOfField(instance, ReflectionUtils.getFieldWithName(instance.getClass(), fieldName)));
+    }
+
+}

--- a/src/test/java/io/beanmapper/shared/ReflectionUtils.java
+++ b/src/test/java/io/beanmapper/shared/ReflectionUtils.java
@@ -1,0 +1,25 @@
+package io.beanmapper.shared;
+
+import java.lang.reflect.Field;
+
+public final class ReflectionUtils {
+
+    public static <T> Object getValueOfField(final T instance, final Field field) {
+        if (!field.canAccess(instance))
+            field.setAccessible(true);
+        try {
+            return field.get(instance);
+        } catch (IllegalArgumentException | IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static <T> Field getFieldWithName(final Class<T> clazz, final String fieldName) {
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/ConstructorArgumentsTest.java
+++ b/src/test/java/io/beanmapper/strategy/ConstructorArgumentsTest.java
@@ -1,0 +1,35 @@
+package io.beanmapper.strategy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.beanmapper.config.BeanPair;
+import io.beanmapper.core.BeanMatch;
+import io.beanmapper.core.BeanMatchStore;
+import io.beanmapper.testmodel.person.PersonForm;
+import io.beanmapper.testmodel.person.PersonResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConstructorArgumentsTest {
+
+    private BeanPair beanPair;
+    private BeanMatchStore beanMatchStore;
+    private BeanMatch beanMatch;
+    private PersonForm personForm;
+
+    @BeforeEach
+    void setUp() {
+        this.beanPair = new BeanPair(PersonForm.class, PersonResult.class);
+        this.beanMatchStore = new BeanMatchStore(null, null);
+        this.beanMatch = this.beanMatchStore.getBeanMatch(this.beanPair);
+        this.personForm = new PersonForm();
+        this.personForm.setName("Henk");
+        this.personForm.setPlace("Zoetermeer");
+    }
+
+    @Test
+    void testPassNullAsConstructorArgs_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new ConstructorArguments(this.personForm, this.beanMatch, null));
+    }
+}

--- a/src/test/java/io/beanmapper/strategy/MapToRecordStrategyTest.java
+++ b/src/test/java/io/beanmapper/strategy/MapToRecordStrategyTest.java
@@ -1,0 +1,416 @@
+package io.beanmapper.strategy;
+
+import static io.beanmapper.shared.AssertionUtils.assertFieldWithNameHasValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.exceptions.RecordConstructorConflictException;
+import io.beanmapper.exceptions.RecordNoAvailableConstructorsExceptions;
+import io.beanmapper.shared.AssertionUtils;
+import io.beanmapper.shared.ReflectionUtils;
+import io.beanmapper.strategy.record.model.AlternativeResultRecordWithIdAndName;
+import io.beanmapper.strategy.record.model.FormRecordWithId_Name_Place_BankAccount;
+import io.beanmapper.strategy.record.model.FormWithIdAndName;
+import io.beanmapper.strategy.record.model.FormWithId_Name_Place_BankAccount;
+import io.beanmapper.strategy.record.model.FormWithName;
+import io.beanmapper.strategy.record.model.ResultRecordWithIdAndName;
+import io.beanmapper.strategy.record.model.ResultRecordWithId_Name_Place;
+import io.beanmapper.strategy.record.model.ResultRecordWithNameAndPlace;
+import io.beanmapper.strategy.record.model.annotation.bean_alias.form.FormWithCollection;
+import io.beanmapper.strategy.record.model.annotation.bean_alias.form.FormWithId_Name_Place;
+import io.beanmapper.strategy.record.model.annotation.record_construct.RecordWithAllConstructorsExcluded;
+import io.beanmapper.strategy.record.model.annotation.record_construct.RecordWithMultipleForcedConstructors;
+import io.beanmapper.strategy.record.model.collection.form.FormRecordWithList;
+import io.beanmapper.strategy.record.model.collection.form.FormRecordWithMap;
+import io.beanmapper.strategy.record.model.collection.form.FormRecordWithQueue;
+import io.beanmapper.strategy.record.model.collection.form.FormRecordWithSet;
+import io.beanmapper.strategy.record.model.collection.form.FormWithList;
+import io.beanmapper.strategy.record.model.collection.form.FormWithMap;
+import io.beanmapper.strategy.record.model.collection.form.FormWithQueue;
+import io.beanmapper.strategy.record.model.collection.form.FormWithSet;
+import io.beanmapper.strategy.record.model.collection.result.ResultRecordWithList;
+import io.beanmapper.strategy.record.model.collection.result.ResultRecordWithMap;
+import io.beanmapper.strategy.record.model.collection.result.ResultRecordWithName;
+import io.beanmapper.strategy.record.model.collection.result.ResultRecordWithQueue;
+import io.beanmapper.strategy.record.model.collection.result.ResultRecordWithSet;
+import io.beanmapper.strategy.record.model.inheritance.Layer3;
+import io.beanmapper.testmodel.person.Person;
+import io.beanmapper.utils.DefaultValues;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MapToRecordStrategyTest {
+
+    private BeanMapper beanMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.beanMapper = new BeanMapperBuilder().build();
+    }
+
+    @Test
+    void testMapObjectToRecordWithEqualFields() {
+        var form = new FormWithIdAndName();
+        var result = this.beanMapper.map(form, ResultRecordWithIdAndName.class);
+
+        assertEquals(form.id, result.id());
+        assertEquals(form.name, result.name());
+    }
+
+    @Test
+    void testMapObjectToRecordWithFewerFields() {
+        var form = new FormWithIdAndName();
+        var result = this.beanMapper.map(form, ResultRecordWithName.class);
+
+        assertEquals(form.name, result.name());
+        AssertionUtils.assertInstanceDoesNotContainField(result, "id");
+    }
+
+    @Test
+    void testMapObjectToRecordWithMoreFields() {
+        var form = new FormWithName();
+        var result = this.beanMapper.map(form, ResultRecordWithIdAndName.class);
+
+        assertEquals((int) DefaultValues.defaultValueFor(int.class), result.id());
+        assertEquals(form.name, result.name());
+    }
+
+    @Test
+    void testMapObjectWithListToRecord() {
+        var form = new FormWithList();
+        var result = this.beanMapper.map(form, ResultRecordWithList.class);
+
+        assertEquals(form.id, result.id());
+        assertEquals(form.name, result.name());
+        assertEquals(form.numbers.size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(List.of(1, 2, 3)));
+    }
+
+    @Test
+    void testMapObjectWithSetToRecord() {
+        var form = new FormWithSet();
+        var result = this.beanMapper.map(form, ResultRecordWithSet.class);
+
+        assertEquals(form.id, result.id());
+        assertEquals(form.name, result.name());
+        assertEquals(form.numbers.size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(Set.of(1, 2, 3)));
+    }
+
+    @Test
+    void testMapObjectWithQueueToRecord() {
+        var form = new FormWithQueue();
+        var result = this.beanMapper.map(form, ResultRecordWithQueue.class);
+
+        assertEquals(form.id, result.id());
+        assertEquals(form.name, result.name());
+        assertEquals(form.numbers.size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(Set.of(1, 2, 3)));
+    }
+
+    @Test
+    void testMapObjectWithMapToRecord() {
+        var form = new FormWithMap();
+        var result = this.beanMapper.map(form, ResultRecordWithMap.class);
+
+        assertEquals(form.id, result.id());
+        assertEquals(form.name, result.name());
+        assertEquals(form.numbers.size(), result.numbers().size());
+        assertEquals(1, result.numbers().get(1));
+        assertEquals(2, result.numbers().get(2));
+        assertEquals(3, result.numbers().get(3));
+    }
+
+    @Test
+    void testFieldsOfSuperClassAreMappedToRecord() {
+        var form = new Layer3();
+        var result = this.beanMapper.map(form, ResultRecordWithId_Name_Place.class);
+
+        assertEquals(form.name, result.name());
+        assertEquals(form.id, result.id());
+        assertEquals(form.place, result.place());
+    }
+
+    @Test
+    void testMapEmptyObjectToRecord() {
+        var form = new Object();
+        var result = this.beanMapper.map(form, ResultRecordWithIdAndName.class);
+
+        assertEquals(0, result.id());
+        assertNull(result.name());
+    }
+
+    @Test
+    void testCustomDefaultsApplyToFieldsRecordMapping() {
+        this.beanMapper = new BeanMapperBuilder()
+                .addCustomDefaultValue(String.class, "Henk")
+                .addCustomDefaultValue(int.class, 42)
+                .build();
+
+        var form = new Object();
+        var result = this.beanMapper.map(form, ResultRecordWithIdAndName.class);
+
+        assertEquals(42, result.id());
+        assertEquals("Henk", result.name());
+    }
+
+    @Test
+    void testCustomDefaultsApplyToRecordMapping() {
+        var result = this.beanMapper.wrap()
+                .addCustomDefaultValue(ResultRecordWithIdAndName.class, new ResultRecordWithIdAndName(42, "Henk"))
+                .build()
+                .map((Object) null, ResultRecordWithIdAndName.class);
+
+        assertEquals(42, result.id());
+        assertEquals("Henk", result.name());
+    }
+
+    @Test
+    void testMapRecordToRecordWithEqualFields() {
+        var form = new ResultRecordWithIdAndName(42, "Henk");
+        var result = this.beanMapper.map(form, AlternativeResultRecordWithIdAndName.class);
+
+        assertEquals(form.id(), result.id());
+        assertEquals(form.name(), result.name());
+    }
+
+    @Test
+    void testMapRecordToRecordWithFewerFields() {
+        var form = new ResultRecordWithIdAndName(42, "Henk");
+        var result = this.beanMapper.map(form, ResultRecordWithName.class);
+
+        assertEquals(form.name(), result.name());
+    }
+
+    @Test
+    void testMapRecordToRecordWithMoreFields() {
+        var form = new ResultRecordWithName("Henk");
+        var result = this.beanMapper.map(form, ResultRecordWithIdAndName.class);
+
+        assertEquals(form.name(), result.name());
+        assertEquals((int) this.beanMapper.getConfiguration().getDefaultValueForClass(int.class), result.id());
+    }
+
+    @Test
+    void testMapRecordWithListToRecord() {
+        var form = new FormRecordWithList(42, "Henk", List.of("1", "2", "3"));
+        var result = this.beanMapper.map(form, ResultRecordWithList.class);
+
+        assertEquals(form.id(), result.id());
+        assertEquals(form.name(), result.name());
+        assertEquals(form.numbers().size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(List.of(1, 2, 3)));
+    }
+
+    @Test
+    void testMapRecordWithSetToRecord() {
+        var form = new FormRecordWithSet(42, "Henk", Set.of("1", "2", "3"));
+        var result = this.beanMapper.map(form, ResultRecordWithSet.class);
+
+        assertEquals(form.id(), result.id());
+        assertEquals(form.name(), result.name());
+        assertEquals(form.numbers().size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(Set.of(1, 2, 3)));
+    }
+
+    @Test
+    void testMapRecordWithQueueToRecord() {
+        var form = new FormRecordWithQueue(42, "Henk", new ArrayDeque<>() {
+            {
+                add("1");
+                add("2");
+                add("3");
+            }
+        });
+        var result = this.beanMapper.map(form, ResultRecordWithQueue.class);
+
+        assertEquals(form.id(), result.id());
+        assertEquals(form.name(), result.name());
+        assertEquals(form.numbers().size(), result.numbers().size());
+    }
+
+    @Test
+    void testMapRecordWithMapToRecord() {
+        var form = new FormRecordWithMap(42, "Henk", Map.of(1, "1", 2, "2", 3, "3"));
+        var result = this.beanMapper.map(form, ResultRecordWithMap.class);
+
+        assertEquals(form.id(), result.id());
+        assertEquals(form.name(), result.name());
+        assertEquals(1, result.numbers().get(1));
+        assertEquals(2, result.numbers().get(2));
+        assertEquals(3, result.numbers().get(3));
+    }
+
+    @Test
+    void testMapDownsizedSourceClassWithFieldAnnotatedWithBeanAliasToRecord() {
+        var form = new FormWithId_Name_Place_BankAccount(42, "Henk", "Zoetermeer", "NL00ABCD0000000000");
+        var result = this.beanMapper.wrap()
+                .downsizeSource(List.of("abc", "def", "ghi"))
+                .build()
+                .map(form, ResultRecordWithNameAndPlace.class);
+
+        assertEquals(form.abc, result.name());
+        assertEquals(form.ghi, result.place());
+        AssertionUtils.assertInstanceDoesNotContainField(result, "id");
+        AssertionUtils.assertInstanceDoesNotContainField(result, "bankAccount");
+    }
+
+    @Test
+    void testMapClassToDownsizedTargetRecord() {
+        var form = new Person();
+        form.setName("Henk");
+        form.setId(42L);
+        form.setBankAccount("NL00ABCD0000000000");
+        form.setPlace("Zoetermeer");
+
+        var result = this.beanMapper.wrap()
+                .downsizeTarget(List.of("name", "place"))
+                .setTargetClass(ResultRecordWithId_Name_Place.class)
+                .build()
+                .map(form);
+
+        assertNotNull(result);
+        AssertionUtils.assertInstanceContainsField(result, "name");
+        AssertionUtils.assertInstanceContainsField(result, "place");
+        AssertionUtils.assertInstanceDoesNotContainField(result, "bankAccount");
+        AssertionUtils.assertInstanceDoesNotContainField(result, "id");
+        assertFieldWithNameHasValue(result, "name", "Henk");
+        assertFieldWithNameHasValue(result, "place", "Zoetermeer");
+    }
+
+    @Test
+    void testMapDownsizedSourceClassToDownsizedTargetRecord() {
+        var form = new Person();
+        form.setName("Henk");
+        form.setId(42L);
+        form.setBankAccount("NL00ABCD0000000000");
+        form.setPlace("Zoetermeer");
+
+        var result = this.beanMapper.wrap()
+                .downsizeSource(List.of("name", "place", "bankAccount"))
+                .downsizeTarget(List.of("name", "place"))
+                .setTargetClass(ResultRecordWithId_Name_Place.class)
+                .build()
+                .map(form);
+
+        assertNotNull(result);
+        AssertionUtils.assertInstanceContainsField(result, "name");
+        AssertionUtils.assertInstanceContainsField(result, "place");
+        AssertionUtils.assertInstanceDoesNotContainField(result, "bankAccount");
+        AssertionUtils.assertInstanceDoesNotContainField(result, "id");
+        assertFieldWithNameHasValue(result, "name", "Henk");
+        assertFieldWithNameHasValue(result, "place", "Zoetermeer");
+    }
+
+    @Test
+    void testMapDownsizedSourceRecordToRecord() {
+        var form = new FormRecordWithId_Name_Place_BankAccount();
+        var result = this.beanMapper.wrap()
+                .downsizeSource(List.of("name", "place"))
+                .build()
+                .map(form, ResultRecordWithId_Name_Place.class);
+
+        assertEquals(0, result.id());
+        assertEquals(form.name(), result.name());
+        assertEquals(form.place(), result.place());
+    }
+
+    @Test
+    void testMapRecordToDownsizedTargetRecord() {
+        var form = new FormRecordWithId_Name_Place_BankAccount();
+        var result = this.beanMapper.wrap()
+                .downsizeTarget(List.of("name", "place"))
+                .setTargetClass(ResultRecordWithId_Name_Place.class)
+                .build()
+                .map(form);
+
+        assertEquals(form.name(), ReflectionUtils.getValueOfField(result, ReflectionUtils.getFieldWithName(result.getClass(), "name")));
+        assertEquals(form.place(), ReflectionUtils.getValueOfField(result, ReflectionUtils.getFieldWithName(result.getClass(), "place")));
+    }
+
+    @Test
+    void testMapDownsizedSourceRecordToDownsizedTargetRecord() {
+        var form = new FormRecordWithId_Name_Place_BankAccount();
+        var result = this.beanMapper.wrap()
+                .downsizeTarget(List.of("name"))
+                .downsizeSource(List.of("name", "place"))
+                .setTargetClass(ResultRecordWithId_Name_Place.class)
+                .build()
+                .map(form);
+
+        assertEquals(form.name(), ReflectionUtils.getValueOfField(result, ReflectionUtils.getFieldWithName(result.getClass(), "name")));
+        AssertionUtils.assertInstanceDoesNotContainField(result, "id");
+        AssertionUtils.assertInstanceDoesNotContainField(result, "place");
+    }
+
+    @Test
+    void testMapClassWithFieldsAnnotatedWithBeanAliasToRecord() {
+        var form = new FormWithId_Name_Place();
+        var result = this.beanMapper.map(form, ResultRecordWithId_Name_Place.class);
+
+        assertEquals(form.abc, result.name());
+        assertEquals(form.def, result.id());
+        assertEquals(form.ghi, result.place());
+    }
+
+    @Test
+    void testMapClassWithFieldsAnnotatedWithBeanAliasToDissimilarRecord() {
+        var form = new FormWithId_Name_Place();
+        var result = this.beanMapper.map(form, ResultRecordWithIdAndName.class);
+
+        assertEquals(form.abc, result.name());
+        assertEquals(form.def, result.id());
+        AssertionUtils.assertInstanceDoesNotContainField(result, "place");
+    }
+
+    @Test
+    void testMapClassWithListAnnotatedWithBeanAliasToRecord() {
+        var form = new io.beanmapper.strategy.record.model.annotation.bean_alias.form.FormWithList();
+        var result = this.beanMapper.map(form, ResultRecordWithList.class);
+
+        assertEquals(form.abc, result.name());
+        assertEquals(form.def, result.id());
+        assertEquals(form.ghi.size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(List.of(1, 2, 3)));
+        AssertionUtils.assertInstanceDoesNotContainField(result, "place");
+    }
+
+    @Test
+    void testMapClassWithCollectionAnnotatedWithBeanAliasToRecord() {
+        var form = new FormWithCollection();
+        var result = this.beanMapper.map(form, ResultRecordWithList.class);
+
+        assertEquals(form.abc, result.name());
+        assertEquals(form.def, result.id());
+        assertEquals(ArrayList.class, result.numbers().getClass());
+        assertEquals(form.ghi.size(), result.numbers().size());
+        assertTrue(result.numbers().containsAll(List.of(1, 2, 3)));
+        AssertionUtils.assertInstanceDoesNotContainField(result, "place");
+    }
+
+    @Test
+    void testMapToRecordWithMultipleForcedConstructors_ShouldThrow_RecordConstructorConflictException() {
+        var form = new FormWithIdAndName();
+        assertThrows(RecordConstructorConflictException.class, () -> this.beanMapper.map(form, RecordWithMultipleForcedConstructors.class));
+    }
+
+    @Test
+    void testMapToRecordWhereAllConstructorsAreExcluded_ShouldThrow_RecordNoAvailableConstructorsException() {
+        var form = new FormWithIdAndName();
+        var result = assertThrows(RecordNoAvailableConstructorsExceptions.class,
+                () -> this.beanMapper.map(form, RecordWithAllConstructorsExcluded.class));
+        System.out.println(result.getMessage());
+    }
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/AlternativeResultRecordWithIdAndName.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/AlternativeResultRecordWithIdAndName.java
@@ -1,0 +1,4 @@
+package io.beanmapper.strategy.record.model;
+
+public record AlternativeResultRecordWithIdAndName(int id, String name) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/FormRecordWithIdAndName.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/FormRecordWithIdAndName.java
@@ -1,0 +1,4 @@
+package io.beanmapper.strategy.record.model;
+
+public record FormRecordWithIdAndName(int id, String name) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/FormRecordWithId_Name_Place_BankAccount.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/FormRecordWithId_Name_Place_BankAccount.java
@@ -1,0 +1,9 @@
+package io.beanmapper.strategy.record.model;
+
+public record FormRecordWithId_Name_Place_BankAccount(int id, String name, String place, String bankAccount) {
+
+    public FormRecordWithId_Name_Place_BankAccount() {
+        this(42, "Henk", "Zoetermeer", "NL00ABCD0000000000");
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/FormWithIdAndName.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/FormWithIdAndName.java
@@ -1,0 +1,14 @@
+package io.beanmapper.strategy.record.model;
+
+public class FormWithIdAndName extends FormWithName {
+    public final int id;
+
+    public FormWithIdAndName(final int id, final String name) {
+        super(name);
+        this.id = id;
+    }
+
+    public FormWithIdAndName() {
+        this(42, "Henk");
+    }
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/FormWithId_Name_Place_BankAccount.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/FormWithId_Name_Place_BankAccount.java
@@ -1,0 +1,17 @@
+package io.beanmapper.strategy.record.model;
+
+import io.beanmapper.strategy.record.model.annotation.bean_alias.form.FormWithId_Name_Place;
+
+public class FormWithId_Name_Place_BankAccount extends FormWithId_Name_Place {
+
+    public final String bankAccount;
+
+    public FormWithId_Name_Place_BankAccount(final int id, final String name, final String place, final String bankAccount) {
+        super(id, name, place);
+        this.bankAccount = bankAccount;
+    }
+
+    public FormWithId_Name_Place_BankAccount() {
+        this(42, "Henk", "Zoetermeer", "NL00ABCD0000000000");
+    }
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/FormWithName.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/FormWithName.java
@@ -1,0 +1,15 @@
+package io.beanmapper.strategy.record.model;
+
+public class FormWithName {
+
+    public final String name;
+
+    public FormWithName(final String name) {
+        this.name = name;
+    }
+
+    public FormWithName() {
+        this("Henk");
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/ResultRecordWithIdAndName.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/ResultRecordWithIdAndName.java
@@ -1,0 +1,4 @@
+package io.beanmapper.strategy.record.model;
+
+public record ResultRecordWithIdAndName(int id, String name) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/ResultRecordWithId_Name_Place.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/ResultRecordWithId_Name_Place.java
@@ -1,0 +1,4 @@
+package io.beanmapper.strategy.record.model;
+
+public record ResultRecordWithId_Name_Place(int id, String name, String place) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/ResultRecordWithNameAndPlace.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/ResultRecordWithNameAndPlace.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model;
+
+import io.beanmapper.annotations.BeanProperty;
+
+public record ResultRecordWithNameAndPlace(@BeanProperty("abc") String name, @BeanProperty("ghi") String place) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/annotation/bean_alias/form/FormWithCollection.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/annotation/bean_alias/form/FormWithCollection.java
@@ -1,0 +1,27 @@
+package io.beanmapper.strategy.record.model.annotation.bean_alias.form;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.beanmapper.annotations.BeanAlias;
+
+public class FormWithCollection {
+
+    @BeanAlias("name")
+    public final String abc;
+    @BeanAlias("id")
+    public final int def;
+    @BeanAlias("numbers")
+    public final Collection<String> ghi;
+
+    public FormWithCollection(final int id, final String name, final Collection<String> numbers) {
+        this.abc = name;
+        this.def = id;
+        this.ghi = numbers;
+    }
+
+    public FormWithCollection() {
+        this(42, "Henk", List.of("1", "2", "3"));
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/annotation/bean_alias/form/FormWithId_Name_Place.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/annotation/bean_alias/form/FormWithId_Name_Place.java
@@ -1,0 +1,24 @@
+package io.beanmapper.strategy.record.model.annotation.bean_alias.form;
+
+import io.beanmapper.annotations.BeanAlias;
+
+public class FormWithId_Name_Place {
+
+    @BeanAlias("name")
+    public String abc;
+    @BeanAlias("id")
+    public int def;
+    @BeanAlias("place")
+    public String ghi;
+
+    public FormWithId_Name_Place(final int id, final String name, String place) {
+        this.def = id;
+        this.abc = name;
+        this.ghi = place;
+    }
+
+    public FormWithId_Name_Place() {
+        this(42, "Henk", "Zoetermeer");
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/annotation/bean_alias/form/FormWithList.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/annotation/bean_alias/form/FormWithList.java
@@ -1,0 +1,26 @@
+package io.beanmapper.strategy.record.model.annotation.bean_alias.form;
+
+import java.util.List;
+
+import io.beanmapper.annotations.BeanAlias;
+
+public class FormWithList {
+
+    @BeanAlias("name")
+    public final String abc;
+    @BeanAlias("id")
+    public final int def;
+    @BeanAlias("numbers")
+    public final List<String> ghi;
+
+    public FormWithList(final int id, final String name, final List<String> numbers) {
+        this.def = id;
+        this.abc = name;
+        this.ghi = numbers;
+    }
+
+    public FormWithList() {
+        this(42, "Henk", List.of("1", "2", "3"));
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/annotation/record_construct/RecordWithAllConstructorsExcluded.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/annotation/record_construct/RecordWithAllConstructorsExcluded.java
@@ -1,0 +1,12 @@
+package io.beanmapper.strategy.record.model.annotation.record_construct;
+
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+
+public record RecordWithAllConstructorsExcluded(int id, String name) {
+
+    @RecordConstruct(constructMode = RecordConstructMode.EXCLUDE)
+    public RecordWithAllConstructorsExcluded {
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/annotation/record_construct/RecordWithMultipleForcedConstructors.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/annotation/record_construct/RecordWithMultipleForcedConstructors.java
@@ -1,0 +1,17 @@
+package io.beanmapper.strategy.record.model.annotation.record_construct;
+
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+
+public record RecordWithMultipleForcedConstructors(int id, String name) {
+
+    @RecordConstruct(constructMode = RecordConstructMode.FORCE)
+    public RecordWithMultipleForcedConstructors {
+    }
+
+    @RecordConstruct(constructMode = RecordConstructMode.FORCE)
+    public RecordWithMultipleForcedConstructors() {
+        this(42, "Henk");
+    }
+    
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithList.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithList.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.List;
+
+public record FormRecordWithList(int id, String name, List<String> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithMap.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithMap.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.Map;
+
+public record FormRecordWithMap(int id, String name, Map<Integer, String> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithQueue.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithQueue.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.Queue;
+
+public record FormRecordWithQueue(int id, String name, Queue<String> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithSet.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormRecordWithSet.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.Set;
+
+public record FormRecordWithSet(int id, String name, Set<String> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithList.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithList.java
@@ -1,0 +1,20 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.List;
+
+import io.beanmapper.strategy.record.model.FormWithIdAndName;
+
+public class FormWithList extends FormWithIdAndName {
+
+    public final List<String> numbers;
+
+    public FormWithList(final int id, final String name, final List<String> numbers) {
+        super(id, name);
+        this.numbers = numbers;
+    }
+
+    public FormWithList() {
+        this.numbers = List.of("1", "2", "3");
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithMap.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithMap.java
@@ -1,0 +1,20 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.Map;
+
+import io.beanmapper.strategy.record.model.FormWithIdAndName;
+
+public class FormWithMap extends FormWithIdAndName {
+
+    public final Map<Integer, String> numbers;
+
+    public FormWithMap(final int id, final String name, final Map<Integer, String> numbers) {
+        super(id, name);
+        this.numbers = numbers;
+    }
+
+    public FormWithMap() {
+        this.numbers = Map.of(1, "1", 2, "2", 3, "3");
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithQueue.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithQueue.java
@@ -1,0 +1,27 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import io.beanmapper.strategy.record.model.FormWithIdAndName;
+
+public class FormWithQueue extends FormWithIdAndName {
+
+    public final Queue<String> numbers;
+
+    public FormWithQueue(final int id, final String name, final Queue<String> numbers) {
+        super(id, name);
+        this.numbers = numbers;
+    }
+
+    public FormWithQueue() {
+        this.numbers = new ArrayDeque<>() {
+            {
+                add("1");
+                add("2");
+                add("3");
+            }
+        };
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithSet.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/form/FormWithSet.java
@@ -1,0 +1,20 @@
+package io.beanmapper.strategy.record.model.collection.form;
+
+import java.util.Set;
+
+import io.beanmapper.strategy.record.model.FormWithIdAndName;
+
+public class FormWithSet extends FormWithIdAndName {
+
+    public final Set<String> numbers;
+
+    public FormWithSet(final int id, final String name, final Set<String> numbers) {
+        super(id, name);
+        this.numbers = numbers;
+    }
+
+    public FormWithSet() {
+        this.numbers = Set.of("1", "2", "3");
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithList.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithList.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.result;
+
+import java.util.List;
+
+public record ResultRecordWithList(int id, String name, List<Integer> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithMap.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithMap.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.result;
+
+import java.util.Map;
+
+public record ResultRecordWithMap(int id, String name, Map<Integer, Integer> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithName.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithName.java
@@ -1,0 +1,4 @@
+package io.beanmapper.strategy.record.model.collection.result;
+
+public record ResultRecordWithName(String name) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithQueue.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithQueue.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.result;
+
+import java.util.Queue;
+
+public record ResultRecordWithQueue(int id, String name, Queue<Integer> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithSet.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/collection/result/ResultRecordWithSet.java
@@ -1,0 +1,6 @@
+package io.beanmapper.strategy.record.model.collection.result;
+
+import java.util.Set;
+
+public record ResultRecordWithSet(int id, String name, Set<Integer> numbers) {
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/inheritance/Layer1.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/inheritance/Layer1.java
@@ -1,0 +1,15 @@
+package io.beanmapper.strategy.record.model.inheritance;
+
+public class Layer1 {
+
+    public final int id;
+
+    public Layer1(final int id) {
+        this.id = id;
+    }
+
+    public Layer1() {
+        this(42);
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/inheritance/Layer2.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/inheritance/Layer2.java
@@ -1,0 +1,16 @@
+package io.beanmapper.strategy.record.model.inheritance;
+
+public class Layer2 extends Layer1 {
+
+    public final String name;
+
+    public Layer2(final int id, final String name) {
+        super(id);
+        this.name = name;
+    }
+
+    public Layer2() {
+        this.name = "Henk";
+    }
+
+}

--- a/src/test/java/io/beanmapper/strategy/record/model/inheritance/Layer3.java
+++ b/src/test/java/io/beanmapper/strategy/record/model/inheritance/Layer3.java
@@ -1,0 +1,16 @@
+package io.beanmapper.strategy.record.model.inheritance;
+
+public class Layer3 extends Layer2 {
+
+    public final String place;
+
+    public Layer3(final int id, final String name, final String place) {
+        super(id, name);
+        this.place = place;
+    }
+
+    public Layer3() {
+        this.place = "Zoetermeer";
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/collections/target_is_wrapped/UnwrappedToWrappedBeanConverter.java
+++ b/src/test/java/io/beanmapper/testmodel/collections/target_is_wrapped/UnwrappedToWrappedBeanConverter.java
@@ -7,13 +7,13 @@ import io.beanmapper.core.converter.BeanConverter;
 public class UnwrappedToWrappedBeanConverter implements BeanConverter {
 
     @Override
-    public Object convert(BeanMapper beanMapper, Object source, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
+    public Object convert(BeanMapper beanMapper, Object source, Class targetClass, BeanPropertyMatch beanPropertyMatch) {
         UnwrappedSource unwrappedSource = (UnwrappedSource) source;
         return new WrappedTarget(unwrappedSource);
     }
 
     @Override
-    public boolean match(Class<?> sourceClass, Class<?> targetClass) {
+    public boolean match(Class sourceClass, Class targetClass) {
         return sourceClass.equals(UnwrappedSource.class) &&
                 targetClass.equals(WrappedTarget.class);
     }

--- a/src/test/java/io/beanmapper/testmodel/construct/SourceBeanConstructWithList.java
+++ b/src/test/java/io/beanmapper/testmodel/construct/SourceBeanConstructWithList.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.construct;
+
+import java.util.List;
+
+public class SourceBeanConstructWithList {
+
+    public List<String> numbers = List.of("1", "2", "3");
+
+}

--- a/src/test/java/io/beanmapper/testmodel/construct/TargetBeanConstructWithList.java
+++ b/src/test/java/io/beanmapper/testmodel/construct/TargetBeanConstructWithList.java
@@ -1,0 +1,20 @@
+package io.beanmapper.testmodel.construct;
+
+import java.util.List;
+
+import io.beanmapper.annotations.BeanConstruct;
+
+@BeanConstruct("numbers")
+public class TargetBeanConstructWithList {
+
+    private final List<Integer> numbers;
+
+    public TargetBeanConstructWithList(final List<Integer> numbers) {
+        this.numbers = numbers;
+    }
+
+    public List<Integer> getNumbers() {
+        return this.numbers;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/DissimilarPersonRecord.java
+++ b/src/test/java/io/beanmapper/testmodel/record/DissimilarPersonRecord.java
@@ -1,0 +1,4 @@
+package io.beanmapper.testmodel.record;
+
+public record DissimilarPersonRecord(long id, String name) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/EntityRecordWithBeanCollection.java
+++ b/src/test/java/io/beanmapper/testmodel/record/EntityRecordWithBeanCollection.java
@@ -1,0 +1,8 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public record EntityRecordWithBeanCollection(int id, String name, @BeanCollection(elementType = Tag.class) List<String> tags) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/EntityResultClass.java
+++ b/src/test/java/io/beanmapper/testmodel/record/EntityResultClass.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.List;
+
+public class EntityResultClass {
+
+    public int id;
+    public String name;
+    public List<Tag> tags;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/PersonForm.java
+++ b/src/test/java/io/beanmapper/testmodel/record/PersonForm.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.record;
+
+import io.beanmapper.annotations.BeanAlias;
+
+public class PersonForm {
+
+    @BeanAlias("id")
+    public int abc;
+    public String name;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/PersonRecord.java
+++ b/src/test/java/io/beanmapper/testmodel/record/PersonRecord.java
@@ -1,0 +1,17 @@
+package io.beanmapper.testmodel.record;
+
+import io.beanmapper.annotations.RecordConstruct;
+
+public record PersonRecord(int id, String name) {
+
+    @RecordConstruct(value = "name")
+    public PersonRecord(String name) {
+        this(1, name);
+    }
+
+    @RecordConstruct(value = {"name", "id"})
+    public PersonRecord(String name, int id) {
+        this(id, name);
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/PersonRecordNonStrict.java
+++ b/src/test/java/io/beanmapper/testmodel/record/PersonRecordNonStrict.java
@@ -1,0 +1,4 @@
+package io.beanmapper.testmodel.record;
+
+public record PersonRecordNonStrict(String name) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/PersonRecordWithNestedRecord.java
+++ b/src/test/java/io/beanmapper/testmodel/record/PersonRecordWithNestedRecord.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.record;
+
+public record PersonRecordWithNestedRecord(int id, NestedRecord result) {
+
+    public record NestedRecord(String name) {}
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/PersonResultRecord.java
+++ b/src/test/java/io/beanmapper/testmodel/record/PersonResultRecord.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.record;
+
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+
+public record PersonResultRecord(int id, String name) {
+
+    @RecordConstruct(value = { "id", "name" }, constructMode = RecordConstructMode.FORCE)
+    public PersonResultRecord {
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/PersonResultRecordWithNestedResult.java
+++ b/src/test/java/io/beanmapper/testmodel/record/PersonResultRecordWithNestedResult.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.record;
+
+public class PersonResultRecordWithNestedResult {
+
+    public int id;
+    public PersonResultRecordWithNestedResult.PersonResult result;
+
+    public static class PersonResult {
+        public String name;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/SourceMapElement.java
+++ b/src/test/java/io/beanmapper/testmodel/record/SourceMapElement.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.record;
+
+public class SourceMapElement {
+
+    private String id = "1";
+
+    public String getId() {
+        return this.id;
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/SourceRecordWithMap.java
+++ b/src/test/java/io/beanmapper/testmodel/record/SourceRecordWithMap.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.Map;
+
+public record SourceRecordWithMap(int id, Map<Long, SourceMapElement> fields) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/SourceRecordWithQueue.java
+++ b/src/test/java/io/beanmapper/testmodel/record/SourceRecordWithQueue.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.Queue;
+
+public record SourceRecordWithQueue(int id, Queue<String> numbers) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/SourceRecordWithSet.java
+++ b/src/test/java/io/beanmapper/testmodel/record/SourceRecordWithSet.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.Set;
+
+public record SourceRecordWithSet(int id, Set<String> numbers) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/Tag.java
+++ b/src/test/java/io/beanmapper/testmodel/record/Tag.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.record;
+
+public class Tag {
+
+    public String name;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetMapElement.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetMapElement.java
@@ -1,0 +1,7 @@
+package io.beanmapper.testmodel.record;
+
+public class TargetMapElement {
+
+    public int id;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetRecordAllowsNull.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetRecordAllowsNull.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.record;
+
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+
+public record TargetRecordAllowsNull(String name, int id, int age) {
+
+    @RecordConstruct(value = { "name", "id", "age" }, allowNull = true, constructMode = RecordConstructMode.FORCE)
+    public TargetRecordAllowsNull {
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithMap.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithMap.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.Map;
+
+public record TargetRecordWithMap(int id, Map<Long, TargetMapElement> fields) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithMultipleForcedConstructors.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithMultipleForcedConstructors.java
@@ -1,0 +1,17 @@
+package io.beanmapper.testmodel.record;
+
+import io.beanmapper.annotations.RecordConstruct;
+import io.beanmapper.annotations.RecordConstructMode;
+
+public record TargetRecordWithMultipleForcedConstructors(int id, String name) {
+
+    @RecordConstruct(value = "id", constructMode = RecordConstructMode.FORCE)
+    public TargetRecordWithMultipleForcedConstructors(int id) {
+        this(id, "Henk");
+    }
+
+    @RecordConstruct(value = "name", constructMode = RecordConstructMode.FORCE)
+    public TargetRecordWithMultipleForcedConstructors(String name) {
+        this(1, name);
+    }
+}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithQueue.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithQueue.java
@@ -1,0 +1,5 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.Queue;
+
+public record TargetRecordWithQueue(int id, Queue<Long> numbers) {}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithSet.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithSet.java
@@ -1,0 +1,6 @@
+package io.beanmapper.testmodel.record;
+
+import java.util.Set;
+
+public record TargetRecordWithSet(int id, Set<Long> numbers) {
+}

--- a/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithoutAnnotations.java
+++ b/src/test/java/io/beanmapper/testmodel/record/TargetRecordWithoutAnnotations.java
@@ -1,0 +1,8 @@
+package io.beanmapper.testmodel.record;
+
+public record TargetRecordWithoutAnnotations(String name) {
+
+    public TargetRecordWithoutAnnotations {
+    }
+
+}

--- a/src/test/java/io/beanmapper/utils/RecordsTest.java
+++ b/src/test/java/io/beanmapper/utils/RecordsTest.java
@@ -1,0 +1,35 @@
+package io.beanmapper.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import io.beanmapper.testmodel.record.PersonRecord;
+
+import org.junit.jupiter.api.Test;
+
+class RecordsTest {
+
+    @Test
+    void testGetRecordFieldNames() {
+        var result = Records.getRecordFieldNames(PersonRecord.class);
+        assertEquals(2, result.length);
+        assertEquals("id", result[0]);
+        assertEquals("name", result[1]);
+    }
+
+    @Test
+    void testGetCanonicalConstructorOfRecord() {
+        var canonicalConstructor = assertDoesNotThrow(() -> Records.getCanonicalConstructorOfRecord(PersonRecord.class));
+        assertEquals(assertDoesNotThrow(() -> PersonRecord.class.getConstructor(int.class, String.class)), canonicalConstructor);
+    }
+
+    @Test
+    void testGetRecordConstructAnnotatedConstructors() {
+        List<Constructor<PersonRecord>> constructors = (List<Constructor<PersonRecord>>) Records.getConstructorsAnnotatedWithRecordConstruct(PersonRecord.class);
+        assertEquals(assertDoesNotThrow(() -> PersonRecord.class.getConstructor(String.class, int.class)), constructors.get(0));
+        assertEquals(assertDoesNotThrow(() -> PersonRecord.class.getConstructor(String.class)), constructors.get(1));
+    }
+
+}


### PR DESCRIPTION
- Improved the use of generics in BeanConverter, and its derived
  classes.
- Changed AbstractBeanConverter#convert, to allow the mapping of null to
  primitives, by using the default value for the relevant primitive,
  using Configuration#getDefaultValuesForClass(Class).
- Modified AbstractMapStrategy#convert, to offer null-values to
  BeanConverters.
- Added AssertionUtils to tests, containing some useful macros for
  certain tedious-to-write assertions.
- Added documentation to BeanAlias, to - hopefully - make it easier to
  understand its purpose, and map its valid use-cases.
- Improved the use of generics in the BeanMapper-class.
- Added the RecordToAnyConverter to the default converters in
  BeanMapperBuilder#addDefaultConverters().
- Added BeanMapperBuilder#addCustomDefaultValue(Class, Object), which
  allows users to set their own defaults, even allowing defaults for
  complex objects.
- Added MappingException, to create a common super-class for exceptions
  relating to bean-mapping and record-mapping.
- Replaced conditionals where an annotation is compared with null with
  usages of Class#isAnnotationPresent(Class).
- Added ClassGenerator#createClassDerivedFromRecord(Class, Set<String>),
  which dynamically creates a class based off of a Record-class, setting
  the field-modifiers to public.
- Fixed a bug in ClassGeneratorTest, where the Exceptions thrown in the
  threads would never be caught in the
  ClassGeneratorTest#shouldNotFailConcurrently()-method, as Exceptions
  thrown in threads are propagated as Throwable, not Exception.
- Added PropertyAccessor#isAnnotationPresent(Class), which checks
  whether the given annotation-class is present on the accessor.
- Added Configuration#addCustomDefaultValueForClass(Class, Object),
  which allows users to set default values for any type during runtime.
- Added Configuration#getDefaultValueForClass(Class), which allows the
  user to retrieve a default value mapped to a given class. This method
  will search the custom default values first, the default values in the
  DefaultValues-class second, and lastly, if no value is found, will
  return null.
- Added check to ConstructorArguments-constructor, to ensure that the
  constructorArgs-array is never null.
- Added a Map<Class, Object> to CoreConfiguration and
  OverrideConfiguration, to allow for the storing of custom default
  values.
- Modified DefaultBeanInitializer#mapParameterizedArguments, to pass a
  ParameterizedType to BeanMapper#map(Object, ParameterizedType) when
  appropriate.
- Added defaults for Optional, List, Set and Map to DefaultValues.
- Using unsupported methods in the PropertyAccessor-implementations now
  result in an UnsupportedOperationException being thrown.
- Improved usage of generics in MapStrategy and implementing classes.
- Modified MapToClassStrategy#map(Object) to let the
  RecordToAnyConverter handle a source Record.
- Added MapToRecordStrategy, which is used to map a source to a Record.
  Somewhat similar to the way a class annotated with BeanConstruct is
  mapped.
- Instances where Field#setAccessible(boolean) is called, are now
  preceded by a check to make certain that those fields are
  inaccessible.
- PrimitiveConvert will no longer throw an Exception when null is passed
  as the source to
  PrimitiveConverter#convert(BeanMapper, Object, Class,
  BeanPropertyMatch). Rather, the default value for the target-class is
  retrieved and returned.
- Added PropertyAccessors#findPropertyDescriptorsForRecord(Class), which
  compiles a Map<String, PropertyDescriptor>, based on the names of the
  RecordComponent-objects of the Record, and their accessors.
- Added RecordConstruct, which provides runtime-instructions to
  BeanMapper.
- Added RecordConstructMode, can be used to set which constructor in a
  Record should be used, or excluded, by BeanMapper, while mapping to a
  Record.
- Added RecordConstructorConflictException, which will be thrown while
  attempting to map to a record which has multiple constructors set with
  the constructMode-option set to RecordConstructMode.FORCE. Notifies
  the user of the constructors with the conflicting constructors.
- Added RecordToAnyConverter, which is used to dynamically create a
  class, based off of the source Record. The dynamically generated class
  is then used as an intermediary between the Record and the
  target-class.
- Added SourceFieldAccessException, which is thrown when the
  MapToRecordStrategy cannot access a field in the target Record.
- Removed slf4j-api dependency, as it is transitive through
  jcl-over-slf4j.
- Added tests to improve coverage.
- Updated CHANGELOG.md.