### PR TITLE
Added array-mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for mapping Queue. A Queue will be mapped to an ArrayDeque by default. The order of elements is guaranteed to be preserved, except when the Queue is
   mapped to a Queue that inherently modifies the order of elements (e.g. PriorityQueue).
 - BeanMapper#map(Queue, Class) allowing users to map a Queue to a new Queue, mapping the elements of the source to the target class.
+- BeanMapper#map(Object[], Class) allowing users to map an array to an array with elements of the type of the target class.
 
 ### Changed
 

--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -1,5 +1,7 @@
 package io.beanmapper;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +76,21 @@ public final class BeanMapper {
                 .setTargetClass(targetClass)
                 .build()
                 .map(source);
+    }
+
+    /**
+     * Maps the source array to an array with the type of the target class.
+     *
+     * @param sourceArray The source array.
+     * @param targetClass The class to which the elements from the source array will be converted to.
+     * @return A newly constructed array of the type of the target class.
+     * @param <S> The type of the elements in the source array.
+     * @param <T> The type of the elements in the target array.
+     */
+    public <S, T> T[] map(S[] sourceArray, Class<T> targetClass) {
+        return Arrays.stream(sourceArray)
+                .map(element -> this.wrap().setConverterChoosable(true).build().map(element, targetClass))
+                .toArray(element -> (T[]) Array.newInstance(targetClass, sourceArray.length));
     }
 
     /**

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -30,7 +30,12 @@ import io.beanmapper.core.unproxy.BeanUnproxy;
 import io.beanmapper.exceptions.BeanMissingPathException;
 import io.beanmapper.exceptions.BeanNoSuchPropertyException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class BeanMatchStore {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final CollectionHandlerStore collectionHandlerStore;
 
@@ -269,7 +274,11 @@ public class BeanMatchStore {
                         new BeanPropertyCreator(matchupDirection.getInverse(), otherType, wrapper.getName())
                                 .determineNodesForPath());
             } catch (BeanNoSuchPropertyException err) {
-                // Acceptable, might have been tagged as @BeanProperty as well
+                if (logger.isDebugEnabled()) {
+                    logger.debug("""
+                            BeanNoSuchPropertyException thrown by BeanMatchStore#dealWithBeanProperty(BeanPropertyMatchupDirection, Map<String, BeanProperty>, Class, PropertyAccessor), for {}.
+                            {}""", accessor.getName(), err.getMessage());
+                }
             }
         }
         return wrapper;

--- a/src/test/java/io/beanmapper/BeanMapperTest.java
+++ b/src/test/java/io/beanmapper/BeanMapperTest.java
@@ -1,5 +1,6 @@
 package io.beanmapper;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -212,7 +213,6 @@ import io.beanmapper.testmodel.tostring.SourceWithNonString;
 import io.beanmapper.testmodel.tostring.TargetWithString;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class BeanMapperTest {
@@ -1774,9 +1774,9 @@ class BeanMapperTest {
         var result = this.beanMapper.map(collection, PersonResult.class);
         assertEquals(HashSet.class, result.getClass());
         assertEquals(3, result.size());
-        assertTrue(result.stream().filter(coll -> coll.name.equals("Henk")).toList().size() == 1);
-        assertTrue(result.stream().filter(coll -> coll.name.equals("Klaas")).toList().size() == 1);
-        assertTrue(result.stream().filter(coll -> coll.name.equals("Kees")).toList().size() == 1);
+        assertEquals(1, result.stream().filter(coll -> coll.name.equals("Henk")).toList().size());
+        assertEquals(1, result.stream().filter(coll -> coll.name.equals("Klaas")).toList().size());
+        assertEquals(1, result.stream().filter(coll -> coll.name.equals("Kees")).toList().size());
         assertTrue(result.stream().filter(coll -> coll.name.equals("Broheim")).toList().isEmpty());
     }
 
@@ -1843,6 +1843,28 @@ class BeanMapperTest {
         assertTrue(result.contains(42L));
         assertTrue(result.contains(21L));
         assertTrue(result.contains(12L));
+    }
+
+    @Test
+    void testMapArray() {
+        var stringArray = new String[] { "1", "2", "3" };
+        var numberArray = this.beanMapper.map(stringArray, Integer.class);
+        assertEquals(stringArray.length, numberArray.length);
+        assertArrayEquals(new Integer[] { 1, 2, 3 }, numberArray);
+    }
+
+    @Test
+    void testMapComplexObjectArrayToArray() {
+        var personFormArray = new Entity[] { new Entity(1L, "Henk", "Henk"), new Entity(2L, "Piet", "Piet"), new Entity(3L, "Klaas", "Klaas") };
+        var resultArray = this.beanMapper.wrap().setApplyStrictMappingConvention(false).build().map(personFormArray, ResultOne.class);
+
+        assertEquals(personFormArray.length, resultArray.length);
+        assertEquals(personFormArray[0].getName(), resultArray[0].getName());
+        assertEquals(personFormArray[1].getName(), resultArray[1].getName());
+        assertEquals(personFormArray[2].getName(), resultArray[2].getName());
+        assertEquals(personFormArray[0].getId(), resultArray[0].getId());
+        assertEquals(personFormArray[1].getId(), resultArray[1].getId());
+        assertEquals(personFormArray[2].getId(), resultArray[2].getId());
     }
 
     private MyEntity createMyEntity() {

--- a/src/test/java/io/beanmapper/testmodel/same_source_diff_results/Entity.java
+++ b/src/test/java/io/beanmapper/testmodel/same_source_diff_results/Entity.java
@@ -6,6 +6,15 @@ public class Entity {
     private String name;
     private String description;
 
+    public Entity(Long id, String name, String description) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+    }
+
+    public Entity() {
+    }
+
     public Long getId() {
         return id;
     }


### PR DESCRIPTION
- Added BeanMapper#map(Object[], Class) allowing users to map an array to a new array of the given type.
- Added tests.
- Expanded logging in BeanMatchStore.
- Updated CHANGELOG.md.