### PR TITLE
Fix for issue #166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Issue [#153](https://github.com/42BV/beanmapper/issues/153) **https://github.com/42BV/beanmapper/issues/153**; Rather than using the Boolean-wrapper, all
   occurrences of Boolean that are not absolutely necessary due to generics, have been replaced with the primitive boolean, or the
   FlushAfterClearInstruction-enum.
+- Issue [#166](https://github.com/42BV/beanmapper/issues/166) **Source with BeanAlias-annotated fields cannot be downsized.**; Modified
+  ClassGenerator#createClass, to check whether a generated field is annotated with BeanAlias. If so, the name of the generated field will be set to the value on
+  the BeanAlias-annotation, and the annotation will be removed from the generated field.
 
 ### Added
 

--- a/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
+++ b/src/main/java/io/beanmapper/dynclass/ClassGenerator.java
@@ -2,6 +2,7 @@ package io.beanmapper.dynclass;
 
 import java.util.Map;
 
+import io.beanmapper.annotations.BeanAlias;
 import io.beanmapper.annotations.BeanCollection;
 import io.beanmapper.config.StrictMappingProperties;
 import io.beanmapper.core.BeanMatchStore;
@@ -58,6 +59,13 @@ public class ClassGenerator {
 
                 // Field must be included -> copy field with related methods
                 CtField generatedField = new CtField(baseField, dynClass);
+                // If the basefield is annotated with BeanAlias, we set the name of the generated field to the value set
+                // on the annotation, and remove the annotation from the generated field.
+                if (baseField.hasAnnotation(BeanAlias.class)) {
+                    generatedField.setName(((BeanAlias) baseField.getAnnotation(BeanAlias.class)).value());
+                    ((AnnotationsAttribute) generatedField.getFieldInfo().getAttribute(AnnotationsAttribute.visibleTag))
+                            .removeAnnotation(BeanAlias.class.getName());
+                }
                 dynClass.addField(generatedField);
 
                 CtMethod readMethod = null;

--- a/src/test/java/io/beanmapper/annotations/BeanAliasTest.java
+++ b/src/test/java/io/beanmapper/annotations/BeanAliasTest.java
@@ -1,0 +1,39 @@
+package io.beanmapper.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.annotations.model.bean_alias.DownsizeForm;
+import io.beanmapper.annotations.model.bean_alias.Result;
+import io.beanmapper.config.BeanMapperBuilder;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BeanAliasTest {
+
+    private BeanMapper beanMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.beanMapper = new BeanMapperBuilder().build();
+    }
+
+    @Test
+    void testDownsizeSourceWithBeanAliasedField() {
+        this.beanMapper = this.beanMapper.wrap()
+                .setApplyStrictMappingConvention(false)
+                .setTargetClass(Result.class)
+                .build();
+
+        var form = new DownsizeForm();
+        form.name = "Henk";
+
+        var result = assertDoesNotThrow(() -> this.beanMapper.map(form));
+
+        assertEquals("Henk", assertDoesNotThrow(() -> result.getClass().getField("test").get(result)));
+
+    }
+
+}

--- a/src/test/java/io/beanmapper/annotations/model/bean_alias/DownsizeForm.java
+++ b/src/test/java/io/beanmapper/annotations/model/bean_alias/DownsizeForm.java
@@ -1,0 +1,10 @@
+package io.beanmapper.annotations.model.bean_alias;
+
+import io.beanmapper.annotations.BeanAlias;
+
+public class DownsizeForm {
+
+    @BeanAlias("test")
+    public String name;
+
+}

--- a/src/test/java/io/beanmapper/annotations/model/bean_alias/Result.java
+++ b/src/test/java/io/beanmapper/annotations/model/bean_alias/Result.java
@@ -1,0 +1,7 @@
+package io.beanmapper.annotations.model.bean_alias;
+
+public class Result {
+
+    public String test;
+
+}


### PR DESCRIPTION
- Modified ClassGenerator#createClass, to check whether a generated field is annotated with BeanAlias. If so, the name of the generated field will be set to the value on the BeanAlias-annotation, and the annotation will be removed from the generated field.