### PR TITLE
Fixes FieldShadowingException for ignored fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   using the @BeanConstruct-annotation.
 - Issue [#132](https://github.com/42BV/beanmapper/issues/132) **Mapping the same field twice ignores one of the mappings.**; Whenever a field is mapped, a check
   will be performed to detect field shadowing in this way. If field shadowing is detected, a FieldShadowingException is thrown. However, a
-  BeanProperty-annotation may take on the name of a field that is non-public and for which an accessor is not exposed.
+  BeanProperty-annotation may take on the name of a field that is non-public and for which an accessor is not exposed. Fields annotated with BeanIgnore are not
+  considered when checking for shadowing.
 - Issue [#149](https://github.com/42BV/beanmapper/issues/149) **Support mapping of JDK 16+ records to classes.**; Added support for mapping record through the
   usual BeanMapper#map(Object, Class<?>)-method.
 - Issue [#152](https://github.com/42BV/beanmapper/issues/152) **Methods that return a Collection should never return null.**; All methods that return a

--- a/src/main/java/io/beanmapper/core/BeanMatchStore.java
+++ b/src/main/java/io/beanmapper/core/BeanMatchStore.java
@@ -320,6 +320,7 @@ public class BeanMatchStore {
         for (var field : fields) {
             var fieldName = field.getName();
             if (!fieldName.equals(accessor.getName())
+                    && !field.isAnnotationPresent(BeanIgnore.class)
                     && fieldName.equals(beanPropertyName)
                     && (Modifier.isPublic(field.getModifiers())
                     || hasAccessibleWriteMethod(field))) {

--- a/src/main/java/io/beanmapper/core/inspector/MethodPropertyAccessor.java
+++ b/src/main/java/io/beanmapper/core/inspector/MethodPropertyAccessor.java
@@ -143,10 +143,9 @@ public class MethodPropertyAccessor implements PropertyAccessor {
      */
     @Override
     public <S> Class<S> getDeclaringClass() {
-        try {
-            return (Class<S>) Class.forName(this.descriptor.getName());
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
+        Method accessor = this.isReadable()
+                ? this.getReadMethod()
+                : this.getWriteMethod();
+        return (Class<S>) accessor.getDeclaringClass();
     }
 }


### PR DESCRIPTION
- Ignoring fields with BeanIgnore-annotation when detecting field shadowing.
- Fixed problem with getting a class using the name of an accessor.