### PR TITLE
Added arbitrarily deep Optional Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for mapping Queue. A Queue will be mapped to an ArrayDeque by default. The order of elements is guaranteed to be preserved, except when the Queue is
   mapped to a Queue that inherently modifies the order of elements (e.g. PriorityQueue).
 - BeanMapper#map(Queue, Class) allowing users to map a Queue to a new Queue, mapping the elements of the source to the target class.
-- BeanMapper#map(Object[], Class) allowing users to map an array to an array with elements of the type of the target class.
+- BeanMapper#map(Object[], Class) allowing users to map an array to an array with elements of the type of the target class. Also works for primitive arrays.
 - Support for mapping to and from JDK16 record-classes.
 - @RecordConstruct-annotation, used to give BeanMapper instructions on how to map a record.
 - RecordConstructMode-enum, which allows the user to exclude certain constructors from being used to map a record, or force one to be used.
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - BeanMapper#map(Object, ParameterizedType), allowing for smarter mapping of collections and optionals.
 - BeanMatchStore#detectBeanPropertyFieldShadowing(PropertyAccessor, io.beanmapper.annotations.BeanProperty), which will throw a FieldShadowingException when
   appropriate.
+- Mapping of Optional-objects to a target class, using BeanMapper#map(Optional, Class).
 
 ### Changed
 

--- a/src/main/java/io/beanmapper/BeanMapper.java
+++ b/src/main/java/io/beanmapper/BeanMapper.java
@@ -61,6 +61,9 @@ public final class BeanMapper {
      * @return the optional target instance containing all applicable properties
      */
     public <S, T> Optional<T> map(Optional<S> source, Class<T> targetClass) {
+        if (source.orElse(null) instanceof Optional<?> optional && !targetClass.isInstance(Optional.class)) {
+            return this.map(optional, targetClass);
+        }
         return source.map(value -> this.map(value, targetClass));
     }
 

--- a/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
+++ b/src/main/java/io/beanmapper/config/BeanMapperBuilder.java
@@ -17,6 +17,7 @@ import io.beanmapper.core.converter.BeanConverter;
 import io.beanmapper.core.converter.collections.CollectionConverter;
 import io.beanmapper.core.converter.impl.AnyToEnumConverter;
 import io.beanmapper.core.converter.impl.NumberToNumberConverter;
+import io.beanmapper.core.converter.impl.ObjectToOptionalConverter;
 import io.beanmapper.core.converter.impl.ObjectToStringConverter;
 import io.beanmapper.core.converter.impl.OptionalToObjectConverter;
 import io.beanmapper.core.converter.impl.PrimitiveConverter;
@@ -251,6 +252,7 @@ public class BeanMapperBuilder {
         attachConverter(new ObjectToStringConverter());
         attachConverter(new OptionalToObjectConverter());
         attachConverter(new RecordToAnyConverter());
+        attachConverter(new ObjectToOptionalConverter());
 
         for (CollectionHandler collectionHandler : configuration.getCollectionHandlers()) {
             attachConverter(new CollectionConverter(collectionHandler));

--- a/src/main/java/io/beanmapper/core/constructor/DefaultBeanInitializer.java
+++ b/src/main/java/io/beanmapper/core/constructor/DefaultBeanInitializer.java
@@ -13,12 +13,16 @@ import java.util.Optional;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
-
-import io.beanmapper.exceptions.BeanConstructException;
 import io.beanmapper.exceptions.BeanInstantiationException;
 import io.beanmapper.strategy.ConstructorArguments;
+import io.beanmapper.utils.DefaultValues;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultBeanInitializer implements BeanInitializer {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * {@inheritDoc}
@@ -33,7 +37,9 @@ public class DefaultBeanInitializer implements BeanInitializer {
             var constructorParameterTypes = Arrays.stream(constructor.getParameters()).map(Parameter::getParameterizedType).toArray(Type[]::new);
             return beanClass.getConstructor(arguments.getTypes()).newInstance(mapParameterizedArguments(constructorParameterTypes, arguments.getValues()));
         } catch (NoSuchMethodException e) {
-            throw new BeanConstructException(beanClass, e);
+            logger.debug(e.getMessage());
+            return DefaultValues.defaultValueFor(beanClass);
+
         } catch (Exception e) {
             throw new BeanInstantiationException(beanClass, e);
         }

--- a/src/main/java/io/beanmapper/core/converter/BeanConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/BeanConverter.java
@@ -22,7 +22,7 @@ public interface BeanConverter {
     <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch);
 
     /**
-     * Determines if the conversion of our source type to a 
+     * Determines whether the conversion of our source type to a
      * target type is supported by this converter.
      * @param sourceClass the source class
      * @param targetClass the target class

--- a/src/main/java/io/beanmapper/core/converter/impl/ObjectToOptionalConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/ObjectToOptionalConverter.java
@@ -1,0 +1,46 @@
+package io.beanmapper.core.converter.impl;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import io.beanmapper.BeanMapper;
+import io.beanmapper.core.BeanPropertyMatch;
+import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.exceptions.BeanNoSuchPropertyException;
+
+/**
+ * This converter facilitates the conversion of an object to an Optional wrapping another object. This converter does
+ * not support the conversion of complex datastructures, such as Collections, to Optionals. If that functionality is
+ * required, please first revise your design. If that is not possible - or undesirable - create a custom converter for
+ * your specific conversion.
+ */
+public class ObjectToOptionalConverter implements BeanConverter {
+
+    @Override
+    public <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch) {
+        if (source == null) {
+            return targetClass.cast(Optional.empty());
+        }
+
+        Field targetField;
+        try {
+            targetField = beanPropertyMatch.getTarget().getClass().getDeclaredField(beanPropertyMatch.getTargetFieldName());
+        } catch (NoSuchFieldException e) {
+            throw new BeanNoSuchPropertyException(e.getMessage());
+        }
+
+        Type targetType = targetField.getGenericType();
+
+        if (targetType instanceof ParameterizedType parameterizedType) {
+            return targetClass.cast(Optional.of(beanMapper.map(source, (Class<?>) parameterizedType.getActualTypeArguments()[0])));
+        }
+        return targetClass.cast(Optional.of(beanMapper.map(source, (Class<?>) targetType)));
+    }
+
+    @Override
+    public boolean match(Class<?> sourceClass, Class<?> targetClass) {
+        return !sourceClass.equals(Optional.class) && targetClass.equals(Optional.class);
+    }
+}

--- a/src/main/java/io/beanmapper/core/converter/impl/OptionalToObjectConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/impl/OptionalToObjectConverter.java
@@ -1,18 +1,64 @@
 package io.beanmapper.core.converter.impl;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.utils.Classes;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This converter facilitates the conversion of an arbitrary amount of Optional wrappers, however, support for complex
+ * datastructures, such as Maps, Sets, List, etc. is limited to a single layer. As such, if the user requires support
+ * deeper layers of complex datastructures within Optionals, they should revise their system design, and if that does
+ * not solve the problem, create a custom converters for their specific conversion.
+ */
 public class OptionalToObjectConverter implements BeanConverter {
 
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public <S, T> T convert(BeanMapper beanMapper, S source, Class<T> targetClass, BeanPropertyMatch beanPropertyMatch) {
         Object obj = ((Optional<?>) source).orElse(null);
-        if (obj != null && obj.getClass().equals(targetClass)) {
-            return (T) obj;
+
+        if (targetClass.equals(Optional.class)) {
+            if (logger.isDebugEnabled()) {
+                // Not always possible to get the actual source class, so just report the name of the field. Debug log will show the call stack.
+                logger.debug("Converting Optional to Optional. Perhaps the target does not need to be an Optional?\nSource-field: {}\nTarget: {}.{}",
+                        beanPropertyMatch.getSourceFieldName(),
+                        beanPropertyMatch.getTarget().getClass(),
+                        beanPropertyMatch.getTargetFieldName());
+            }
+            return targetClass.cast(convertToOptional(beanMapper, (Optional<?>) source, beanPropertyMatch));
+        } else if (obj == null) {
+            return null;
+        } else if (obj.getClass().equals(targetClass)) {
+            return targetClass.cast(obj);
+        } else if (obj instanceof Collection || obj instanceof Map<?, ?>) {
+            return targetClass.cast(convertToCollection(beanMapper, obj, beanPropertyMatch));
+        } else if (obj instanceof Optional<?> optional) {
+            if (Collection.class.isAssignableFrom(targetClass)) {
+                Class<?> genericType = (Class<?>) Classes.getParameteredTypes(beanPropertyMatch.getTarget().getClass(), beanPropertyMatch)[0];
+                if (Set.class.isAssignableFrom(targetClass)) {
+                    return targetClass.cast(beanMapper.map((Set<?>) optional.orElse(null), (Class<?>) genericType));
+                } else {
+                    return targetClass.cast(beanMapper.map((List<?>) optional.orElse(null), (Class<?>) genericType));
+                }
+            }
+            return targetClass.cast(beanMapper.map(optional, targetClass));
         }
         return beanMapper.map(obj, targetClass);
     }
@@ -25,4 +71,39 @@ public class OptionalToObjectConverter implements BeanConverter {
         return sourceClass.equals(Optional.class);
     }
 
+    private Optional<?> convertToOptional(BeanMapper beanMapper, Optional<?> source, BeanPropertyMatch beanPropertyMatch) {
+        if (source.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Get generic type of wrapping Optional
+        Type genericType = Classes.getParameteredTypes(beanPropertyMatch.getTarget().getClass(), beanPropertyMatch)[0];
+
+        // The target Optional may consist of nested Optionals. If so, we start unwrapping, until we get to the actual type.
+        int numberOfWraps = 0;
+        while (genericType instanceof ParameterizedType parameterizedType && parameterizedType.getRawType().equals(Optional.class)) {
+            genericType = parameterizedType.getActualTypeArguments()[0];
+            numberOfWraps++;
+        }
+
+        // Place back in an Optional, as that is the target class
+        Optional<?> obj = Optional.ofNullable(beanMapper.map(source.get(), (Class<?>) genericType));
+
+        // Wrap in as many Optionals as the target requires.
+        for (int index = 0; index < numberOfWraps; index++) {
+            obj = Optional.of(obj);
+        }
+        return obj;
+    }
+
+    private Object convertToCollection(BeanMapper beanMapper, Object source, BeanPropertyMatch beanPropertyMatch) {
+        if (source instanceof Collection<?> collection) {
+            Type genericType = Classes.getParameteredTypes(beanPropertyMatch.getTarget().getClass(), beanPropertyMatch)[0];
+            return beanMapper.map(collection, (Class<?>) genericType);
+        } else if (source instanceof Map<?, ?> map) {
+            Type[] genericTypes = Classes.getParameteredTypes(beanPropertyMatch.getTarget().getClass(), beanPropertyMatch);
+            return new HashMap<>(beanMapper.map((Map<?, ?>) map, (Class<?>) genericTypes[1]));
+        }
+        return beanMapper.getConfiguration().getDefaultValueForClass(source.getClass());
+    }
 }

--- a/src/main/java/io/beanmapper/exceptions/NoSuchFieldInTargetClass.java
+++ b/src/main/java/io/beanmapper/exceptions/NoSuchFieldInTargetClass.java
@@ -1,0 +1,9 @@
+package io.beanmapper.exceptions;
+
+public class NoSuchFieldInTargetClass extends RuntimeException {
+
+    public NoSuchFieldInTargetClass(Throwable throwable, Class<?> targetClass, String fieldName) {
+        super(throwable);
+    }
+
+}

--- a/src/main/java/io/beanmapper/utils/Classes.java
+++ b/src/main/java/io/beanmapper/utils/Classes.java
@@ -6,6 +6,9 @@ package io.beanmapper.utils;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+import io.beanmapper.core.BeanPropertyMatch;
+import io.beanmapper.exceptions.BeanNoSuchPropertyException;
+
 /**
  * Reflection utilities.
  *
@@ -52,6 +55,15 @@ public class Classes {
             classes[index] = Classes.forName(typeName);
         }
         return classes;
+    }
+
+    public static Type[] getParameteredTypes(Class<?> clazz, BeanPropertyMatch beanPropertyMatch) {
+        try {
+            return ((ParameterizedType) clazz.getDeclaredField(beanPropertyMatch.getTargetFieldName())
+                    .getGenericType()).getActualTypeArguments();
+        } catch (NoSuchFieldException e) {
+            throw new BeanNoSuchPropertyException(e.getMessage());
+        }
     }
 
 }

--- a/src/test/java/io/beanmapper/core/converter/impl/OptionalToObjectConverterTest.java
+++ b/src/test/java/io/beanmapper/core/converter/impl/OptionalToObjectConverterTest.java
@@ -5,13 +5,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
+import io.beanmapper.testmodel.optional_getter.EntityFormWithOptionalOfOptional;
 import io.beanmapper.testmodel.optional_getter.MyEntity;
 import io.beanmapper.testmodel.optional_getter.MyEntityResult;
+import io.beanmapper.testmodel.optional_getter.MyEntityResultWithList;
+import io.beanmapper.testmodel.optional_getter.MyEntityWithList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +51,7 @@ class OptionalToObjectConverterTest {
 
     @Test
     void convertEntityWithChild() {
-        var result = this.beanMapper.map(myEntity, MyEntityResult.class);
+        MyEntityResult result = this.beanMapper.map(myEntity, MyEntityResult.class);
         assertEquals(this.myEntity.value, result.value);
         assertEquals(this.myEntity.child.value, result.child.value);
         assertNull(result.child.child);
@@ -83,4 +91,88 @@ class OptionalToObjectConverterTest {
         assertNull(result.child);
     }
 
+    @Test
+    void convertMyEntityWithListToEntityResultWithList() {
+        MyEntityWithList[] children = new MyEntityWithList[] { new MyEntityWithList(), new MyEntityWithList() };
+        children[0].value = "Klaas";
+        children[1].value = "Piet";
+
+        MyEntityWithList form = new MyEntityWithList();
+        form.value = "Henk";
+        form.children = List.of(children);
+
+        var result = this.beanMapper.map(form, MyEntityResultWithList.class);
+        assertEquals(2, result.children.size());
+    }
+
+    @Test
+    void convertEntityWithOptionalOfOptionalOfListToEntityWithList() {
+        EntityFormWithOptionalOfOptional child1 = new EntityFormWithOptionalOfOptional();
+        child1.value = "Klaas";
+        child1.children = Optional.of(Optional.of(Collections.emptyList()));
+
+        EntityFormWithOptionalOfOptional child2 = new EntityFormWithOptionalOfOptional();
+        child2.value = "Piet";
+        child2.children = Optional.of(Optional.of(Collections.emptyList()));
+
+        List<EntityFormWithOptionalOfOptional> children = List.of(child1, child2);
+
+        EntityFormWithOptionalOfOptional form = new EntityFormWithOptionalOfOptional();
+        form.value = "Henk";
+        form.children = Optional.of(Optional.of(children));
+
+        var result = beanMapper.map(form, MyEntityWithList.class);
+        assertEquals("Henk", result.value);
+        assertEquals(2, result.children.size());
+    }
+
+    @Test
+    void convertListWithOptionalToListOfDifferentType() {
+        List<Optional<Integer>> list = List.of(Optional.of(42), Optional.of(23), Optional.empty());
+        List<Long> listOfLong = this.beanMapper.map(list, Long.TYPE);
+        assertEquals(list.size(), listOfLong.size());
+        assertTrue(listOfLong.contains(42L));
+        assertTrue(listOfLong.contains(23L));
+        assertTrue(listOfLong.contains(null));
+    }
+
+    @Test
+    void convertListWithoutOptionalToListOfWithOptional() {
+        List<Optional<Integer>> list = List.of(Optional.of(42), Optional.of(23), Optional.empty());
+        List<Long> listOfLong = this.beanMapper.map(list, Long.TYPE);
+        List<Optional<Integer>> unoReversedList = this.beanMapper.map(listOfLong, Integer.TYPE).stream().map(Optional::ofNullable).toList();
+        assertEquals(list.size(), listOfLong.size());
+        assertTrue(unoReversedList.contains(Optional.of(42)));
+        assertTrue(unoReversedList.contains(Optional.of(23)));
+        assertTrue(unoReversedList.contains(Optional.<Integer>of(this.beanMapper.getConfiguration().getDefaultValueForClass(Integer.TYPE))));
+    }
+
+    @Test
+    void convertMapWithOptionalToMapOfDifferentType() {
+        Map<Integer, Optional<Integer>> map = Map.of(42, Optional.of(42), 23, Optional.of(23));
+        Map<Integer, Optional<Long>> longMap = this.beanMapper.map(map, Long.TYPE).entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry<>(entry.getKey(), Optional.ofNullable(entry.getValue())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        assertEquals(map.size(), longMap.size());
+        assertEquals(Optional.of(42L), longMap.get(42));
+        assertEquals(Optional.of(23L), longMap.get(23));
+    }
+
+    public static class ClassWithOptionalOfListOfOptionalOfInteger {
+        public Optional<List<Optional<Integer>>> list = Optional.of(List.of(Optional.of(1), Optional.of(23), Optional.of(42)));
+    }
+
+    public static class ClassWithListOfLong {
+        public List<Long> list;
+    }
+
+    @Test
+    void convertOptionalOfListToList() {
+        var form = new ClassWithOptionalOfListOfOptionalOfInteger();
+        var result = this.beanMapper.map(form, ClassWithListOfLong.class);
+        assertEquals(3, result.list.size());
+        assertTrue(result.list.contains(1L));
+        assertTrue(result.list.contains(23L));
+        assertTrue(result.list.contains(42L));
+    }
 }

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/EntityFormWithOptionalOfOptional.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/EntityFormWithOptionalOfOptional.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.List;
+import java.util.Optional;
+
+public class EntityFormWithOptionalOfOptional {
+
+    public String value;
+
+    public Optional<Optional<List<EntityFormWithOptionalOfOptional>>> children;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/EntityResultWithMap.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/EntityResultWithMap.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.Map;
+
+public class EntityResultWithMap {
+
+    public String value;
+
+    public Map<String, EntityResultWithMap> children;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/EntityWithMap.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/EntityWithMap.java
@@ -1,0 +1,16 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class EntityWithMap {
+
+    public String value;
+
+    public Map<String, EntityWithMap> children;
+
+    public Optional<Map<String, EntityWithMap>> getChildren() {
+        return Optional.ofNullable(children);
+    }
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/EntityWithOptional.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/EntityWithOptional.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.Optional;
+
+public class EntityWithOptional {
+
+    public String value;
+
+    public Optional<EntityWithOptional> child;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/EntityWithoutOptional.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/EntityWithoutOptional.java
@@ -1,0 +1,9 @@
+package io.beanmapper.testmodel.optional_getter;
+
+public class EntityWithoutOptional {
+
+    public String value;
+
+    public EntityWithoutOptional child;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResultWithList.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResultWithList.java
@@ -1,0 +1,13 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.List;
+
+import io.beanmapper.annotations.BeanCollection;
+
+public class MyEntityResultWithList {
+
+    public String value;
+
+    public List<MyEntityResultWithList> children;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResultWithNestedOptionalField.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResultWithNestedOptionalField.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.Optional;
+
+public class MyEntityResultWithNestedOptionalField {
+
+    public String value;
+
+    public Optional<Optional<MyEntityResultWithNestedOptionalField>> child;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResultWithOptionalField.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityResultWithOptionalField.java
@@ -1,0 +1,11 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.Optional;
+
+public class MyEntityResultWithOptionalField {
+
+    public String value;
+
+    public Optional<MyEntityResultWithOptionalField> child;
+
+}

--- a/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityWithList.java
+++ b/src/test/java/io/beanmapper/testmodel/optional_getter/MyEntityWithList.java
@@ -1,0 +1,12 @@
+package io.beanmapper.testmodel.optional_getter;
+
+import java.util.List;
+import java.util.Optional;
+
+public class MyEntityWithList {
+
+    public String value;
+
+    public List<MyEntityWithList> children;
+
+}


### PR DESCRIPTION
- BeanMapper#map(Optional, Class) should now allows for mapping of Optional<Optional<?>> to a target class. Every Optional may also contain another Optional. The only limit is the recursion limit.
- It is now possible to automatically map Optional<X> to Optional<Y>, due to changes in the OptionalToObjectConverter.
- Supports mapping Optional<List<X>> to Optional<List<Y>>. Same for Sets.
- Added mapping Optional<Map<X>> to Optional<Map<Y>>.