### PR TITLE
fix map to collection docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -245,15 +245,14 @@ Target target = new BeanMapperBuilder().build()
 assertEquals("Henk", target.name);
 assertEquals(42, target.age, 0);</code>
           <h4 id="map-to-collection">Map to a collection</h4>
-          <p>Use this method when you want to map a collection of items to a collection of items of an other type. Of course you can do this for yourself by creating a loop and call map inside each loop. This method is just to make it easy for you.
-          You can also pass a third optional argument to convert the list to. In this case we choose an ArrayList.class.</p>
+          <p>Use this method when you want to map a collection of items to a collection of items of an other type. Of course you can do this for yourself by creating a loop and call map inside each loop. This method is just to make it easy for you.</p>
           <code>List&lt;Source> sources = new ArrayList&lt;Source>();
 sources.add(new Source(1L, "Henk", 42));
 sources.add(new Source(2L, "Piet", 50));
 sources.add(new Source(3L, "Kees", 3));
 
-ArrayList&lt;Target> targets = (ArrayList&lt;Target>) new BeanMapperBuilder().build()
-    .map(sources, Target.class, ArrayList.class);
+List&lt;Target> targets = new BeanMapperBuilder().build()
+    .map(sources, Target.class);
 
 assertEquals(3, targets.size(), 0);
 assertEquals("Henk", targets.get(0).name);

--- a/docs/src/test/java/io/beanmapper/StrategiesExample.java
+++ b/docs/src/test/java/io/beanmapper/StrategiesExample.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import io.beanmapper.BeanMapper;
 import io.beanmapper.config.BeanMapperBuilder;
 
 import org.junit.jupiter.api.Test;
@@ -44,8 +45,8 @@ public class StrategiesExample {
         sources.add(new Source(2L, "Piet", 50));
         sources.add(new Source(3L, "Kees", 3));
 
-        ArrayList<Target> targets = (ArrayList<Target>) new BeanMapperBuilder().build()
-                .map(sources, Target.class, ArrayList.class);
+        List<Target> targets = new BeanMapperBuilder().build()
+                .map(sources, Target.class);
 
         assertEquals(3, targets.size(), 0);
         assertEquals("Henk", targets.get(0).name);
@@ -59,7 +60,7 @@ public class StrategiesExample {
         Source source = new Source(1L, "Henk", 42);
         Target target = new Target("Piet", 12);
 
-        beanMapper.wrapConfig()
+        beanMapper.wrap()
                 .downsizeSource(Arrays.asList("age"))
                 .build()
                 .map(source, target);
@@ -73,7 +74,7 @@ public class StrategiesExample {
         BeanMapper beanMapper = new BeanMapperBuilder().build();
         Source source = new Source(1L, "Henk", 42);
 
-        Object target = beanMapper.wrapConfig()
+        Object target = beanMapper.wrap()
                 .downsizeTarget(Arrays.asList("name"))
                 .build()
                 .map(source, Target.class);


### PR DESCRIPTION
There is no `map` method in BeanMapper with third param in current version as described in docs:

https://github.com/42BV/beanmapper/blob/806b09d150d86c9652f1f03a21139922be9ce946/docs/index.html#L247-L256

`map` methods in BeanMapper current version:
https://github.com/42BV/beanmapper/blob/806b09d150d86c9652f1f03a21139922be9ce946/src/main/java/io/beanmapper/BeanMapper.java#L32-L189