### PR TITLE
[#196/#197] implement caching for unproxy results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Issue [#196](https://github.com/42BV/beanmapper/issues/196) **Calls to the logger should not contain a call to String.formatted(Object...)**; Fixed by removing any formatting from performance logging. Trace-logging should keep the level of detail provided by the formatting.
+- Issue [#197](https://github.com/42BV/beanmapper/issues/197) **Implement caching for Unproxy results.**; Created UnproxyResultStore, allowing for thread-safe caching and retrieval of unproxied classes.
+
 ## [4.1.3] - 2024-03-27
 
 ### Fixed

--- a/src/main/java/io/beanmapper/config/CollectionHandlerStore.java
+++ b/src/main/java/io/beanmapper/config/CollectionHandlerStore.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import io.beanmapper.core.collections.CollectionHandler;
 import io.beanmapper.core.unproxy.BeanUnproxy;
+import io.beanmapper.core.unproxy.UnproxyResultStore;
 
 public class CollectionHandlerStore {
 
@@ -28,7 +29,8 @@ public class CollectionHandlerStore {
             return collectionHandler;
         }
         // Unproxy the collection class in case it was anonymous and try again
-        return getCollectionHandlerFor(beanUnproxy.unproxy(clazz));
+        Class<?> unproxiedClass = UnproxyResultStore.getInstance().getOrComputeUnproxyResult(clazz, beanUnproxy);
+        return getCollectionHandlerFor(unproxiedClass);
     }
 
     private CollectionHandler getCollectionHandlerFor(Class<?> clazz) {

--- a/src/main/java/io/beanmapper/config/OverrideField.java
+++ b/src/main/java/io/beanmapper/config/OverrideField.java
@@ -6,6 +6,7 @@ import io.beanmapper.utils.BeanMapperPerformanceLogger;
 
 public class OverrideField<T> {
 
+    private static final String LOGGING_STRING = "OverrideField#get(void) -> OverrideField#get(void)";
     private final Supplier<T> supplier;
 
     private boolean block = false;
@@ -34,7 +35,7 @@ public class OverrideField<T> {
             return null;
         }
         if (this.value == null) {
-            this.value = BeanMapperPerformanceLogger.runTimed("%s#%s -> %s#%s".formatted(this.getClass().getSimpleName(), "get(void)", this.getClass().getSimpleName(), "get(void)"), this.supplier);
+            this.value = BeanMapperPerformanceLogger.runTimed(LOGGING_STRING, this.supplier);
         }
         return value;
     }

--- a/src/main/java/io/beanmapper/config/StrictMappingProperties.java
+++ b/src/main/java/io/beanmapper/config/StrictMappingProperties.java
@@ -2,6 +2,7 @@ package io.beanmapper.config;
 
 import io.beanmapper.core.unproxy.BeanUnproxy;
 import io.beanmapper.core.unproxy.SkippingBeanUnproxy;
+import io.beanmapper.core.unproxy.UnproxyResultStore;
 import io.beanmapper.utils.BeanMapperPerformanceLogger;
 
 import static io.beanmapper.utils.CanonicalClassName.determineCanonicalClassName;
@@ -84,10 +85,10 @@ public class StrictMappingProperties {
     }
 
     public BeanPair createBeanPair(Class<?> sourceClass, Class<?> targetClass) {
-        BeanPair beanPair = BeanMapperPerformanceLogger.runTimed("%s#%s".formatted(this.getClass().getSimpleName(), "createBeanPair(Class, Class) -> BeanUnproxy#unproxy(Class)"), () -> {
-            Class<?> unproxiedSource = beanUnproxy.unproxy(sourceClass);
-            Class<?> unproxiedTarget = beanUnproxy.unproxy(targetClass);
+        UnproxyResultStore unproxyResultStore = UnproxyResultStore.getInstance();
         BeanPair beanPair = BeanMapperPerformanceLogger.runTimed(LOGGING_STRING, () -> {
+            Class<?> unproxiedSource = unproxyResultStore.getOrComputeUnproxyResult(sourceClass, beanUnproxy);
+            Class<?> unproxiedTarget = unproxyResultStore.getOrComputeUnproxyResult(targetClass, beanUnproxy);
             return new BeanPair(unproxiedSource, unproxiedTarget);
         });
         if (!isApplyStrictMappingConvention()) {

--- a/src/main/java/io/beanmapper/config/StrictMappingProperties.java
+++ b/src/main/java/io/beanmapper/config/StrictMappingProperties.java
@@ -8,6 +8,8 @@ import static io.beanmapper.utils.CanonicalClassName.determineCanonicalClassName
 
 public class StrictMappingProperties {
 
+    private static final String LOGGING_STRING = "StrictMappingProperties#createBeanPair(Class, Class) -> BeanUnproxy#unproxy(Class)";
+
     private BeanUnproxy beanUnproxy;
 
     /**
@@ -85,6 +87,7 @@ public class StrictMappingProperties {
         BeanPair beanPair = BeanMapperPerformanceLogger.runTimed("%s#%s".formatted(this.getClass().getSimpleName(), "createBeanPair(Class, Class) -> BeanUnproxy#unproxy(Class)"), () -> {
             Class<?> unproxiedSource = beanUnproxy.unproxy(sourceClass);
             Class<?> unproxiedTarget = beanUnproxy.unproxy(targetClass);
+        BeanPair beanPair = BeanMapperPerformanceLogger.runTimed(LOGGING_STRING, () -> {
             return new BeanPair(unproxiedSource, unproxiedTarget);
         });
         if (!isApplyStrictMappingConvention()) {

--- a/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
@@ -10,7 +10,7 @@ import io.beanmapper.utils.Classes;
 
 public abstract class AbstractCollectionHandler<C> implements CollectionHandler<C> {
 
-    private static final String LOGGING_STRING = "AbstractCollectionHandler#mapItem(BeanMapper, Class, Object) -> BeanMapper#map(Object)";
+    private static final String LOGGING_STRING = "%s#mapItem(BeanMapper, Class, Object) -> BeanMapper#map(Object)";
 
     private final Class<C> type;
     private final DefaultBeanInitializer beanInitializer = new DefaultBeanInitializer();
@@ -35,13 +35,12 @@ public abstract class AbstractCollectionHandler<C> implements CollectionHandler<
             BeanMapper beanMapper,
             Class<?> collectionElementClass,
             Object source) {
-        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
-                () -> beanMapper.wrap()
+        return BeanMapperPerformanceLogger.runTimed(() -> beanMapper.wrap()
                 .setTargetClass(collectionElementClass)
                 .setCollectionClass(null)
                 .setConverterChoosable(true)
                 .build()
-                .map(source));
+                .map(source), LOGGING_STRING, getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
+++ b/src/main/java/io/beanmapper/core/collections/AbstractCollectionHandler.java
@@ -10,6 +10,8 @@ import io.beanmapper.utils.Classes;
 
 public abstract class AbstractCollectionHandler<C> implements CollectionHandler<C> {
 
+    private static final String LOGGING_STRING = "AbstractCollectionHandler#mapItem(BeanMapper, Class, Object) -> BeanMapper#map(Object)";
+
     private final Class<C> type;
     private final DefaultBeanInitializer beanInitializer = new DefaultBeanInitializer();
 
@@ -33,8 +35,7 @@ public abstract class AbstractCollectionHandler<C> implements CollectionHandler<
             BeanMapper beanMapper,
             Class<?> collectionElementClass,
             Object source) {
-        return BeanMapperPerformanceLogger.runTimed("%s#%s"
-                .formatted(this.getClass().getSimpleName(), "mapItem(BeanMapper, Class, Object) -> BeanMapper#map(Object)"),
+        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
                 () -> beanMapper.wrap()
                 .setTargetClass(collectionElementClass)
                 .setCollectionClass(null)

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -8,6 +8,8 @@ import io.beanmapper.utils.BeanMapperPerformanceLogger;
 
 public class CollectionConverter implements BeanConverter {
 
+    private static final String LOGGING_STRING = "CollectionConverter#convert(BeanMapper, Object, Class, BeanPropertyMatch) -> BeanMapper#map(Object)";
+
     private final CollectionHandler<?> collectionHandler;
 
     public CollectionConverter(CollectionHandler<?> collectionHandler) {
@@ -25,8 +27,7 @@ public class CollectionConverter implements BeanConverter {
             return targetClass.cast(source);
         }
 
-        return BeanMapperPerformanceLogger.runTimed("%s#%s"
-                .formatted(this.getClass().getSimpleName(), "convert(BeanMapper, Object, Class, BeanPropertyMatch) -> BeanMapper#map(Object)"),
+        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
                 () -> beanMapper.wrap()
                 .setCollectionClass(collectionHandler.getType())
                 .setCollectionUsage(beanPropertyMatch.getCollectionInstructions().getBeanCollectionUsage())

--- a/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
+++ b/src/main/java/io/beanmapper/core/converter/collections/CollectionConverter.java
@@ -8,7 +8,7 @@ import io.beanmapper.utils.BeanMapperPerformanceLogger;
 
 public class CollectionConverter implements BeanConverter {
 
-    private static final String LOGGING_STRING = "CollectionConverter#convert(BeanMapper, Object, Class, BeanPropertyMatch) -> BeanMapper#map(Object)";
+    private static final String LOGGING_STRING = "%s#convert(BeanMapper, Object, Class, BeanPropertyMatch) -> BeanMapper#map(Object)";
 
     private final CollectionHandler<?> collectionHandler;
 
@@ -27,8 +27,7 @@ public class CollectionConverter implements BeanConverter {
             return targetClass.cast(source);
         }
 
-        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
-                () -> beanMapper.wrap()
+        return BeanMapperPerformanceLogger.runTimed(() -> beanMapper.wrap()
                 .setCollectionClass(collectionHandler.getType())
                 .setCollectionUsage(beanPropertyMatch.getCollectionInstructions().getBeanCollectionUsage())
                 .setPreferredCollectionClass(beanPropertyMatch.getCollectionInstructions().getPreferredCollectionClass().getAnnotationClass())
@@ -37,7 +36,7 @@ public class CollectionConverter implements BeanConverter {
                 .setTarget(beanPropertyMatch.getTargetObject())
                 .setUseNullValue()
                 .build()
-                .map(source));
+                .map(source), LOGGING_STRING, getClass().getSimpleName());
     }
 
     @Override

--- a/src/main/java/io/beanmapper/core/unproxy/UnproxyResultStore.java
+++ b/src/main/java/io/beanmapper/core/unproxy/UnproxyResultStore.java
@@ -1,0 +1,43 @@
+package io.beanmapper.core.unproxy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Singleton responsible for storing the results of unproxy-results. Allows for fast and thread-safe retrieval of results.
+ */
+public final class UnproxyResultStore {
+
+    private static volatile UnproxyResultStore INSTANCE;
+
+    private final Map<Class<?>, Class<?>> unproxyResultClassStore;
+
+    private UnproxyResultStore() {
+        unproxyResultClassStore = Collections.synchronizedMap(new HashMap<>());
+    }
+
+    /**
+     * Gets or computes the result of an unproxy-operation.
+     *
+     * @param source The class for which the unproxy-result needs to be retrieved or computed.
+     * @param unproxy The BeanUnproxy that will be used to compute an unproxy-result if none exist for the given source-class.
+     * @return The unproxied class.
+     */
+    public Class<?> getOrComputeUnproxyResult(Class<?> source, BeanUnproxy unproxy) {
+        return unproxyResultClassStore.computeIfAbsent(source, unproxy::unproxy);
+    }
+
+    public static UnproxyResultStore getInstance() {
+        if (INSTANCE != null) {
+            return INSTANCE;
+        }
+        synchronized (UnproxyResultStore.class) {
+            if (INSTANCE == null) {
+                INSTANCE = new UnproxyResultStore();
+            }
+        }
+        return INSTANCE;
+    }
+
+}

--- a/src/main/java/io/beanmapper/core/unproxy/UnproxyResultStore.java
+++ b/src/main/java/io/beanmapper/core/unproxy/UnproxyResultStore.java
@@ -1,20 +1,19 @@
 package io.beanmapper.core.unproxy;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Singleton responsible for storing the results of unproxy-results. Allows for fast and thread-safe retrieval of results.
  */
 public final class UnproxyResultStore {
 
-    private static volatile UnproxyResultStore INSTANCE;
+    private static UnproxyResultStore INSTANCE;
 
     private final Map<Class<?>, Class<?>> unproxyResultClassStore;
 
     private UnproxyResultStore() {
-        unproxyResultClassStore = Collections.synchronizedMap(new HashMap<>());
+        unproxyResultClassStore = new ConcurrentHashMap<>();
     }
 
     /**
@@ -28,14 +27,9 @@ public final class UnproxyResultStore {
         return unproxyResultClassStore.computeIfAbsent(source, unproxy::unproxy);
     }
 
-    public static UnproxyResultStore getInstance() {
-        if (INSTANCE != null) {
-            return INSTANCE;
-        }
-        synchronized (UnproxyResultStore.class) {
-            if (INSTANCE == null) {
-                INSTANCE = new UnproxyResultStore();
-            }
+    public static synchronized UnproxyResultStore getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new UnproxyResultStore();
         }
         return INSTANCE;
     }

--- a/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/AbstractMapStrategy.java
@@ -10,6 +10,8 @@ import io.beanmapper.config.Configuration;
 import io.beanmapper.core.BeanMatch;
 import io.beanmapper.core.BeanPropertyMatch;
 import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.core.unproxy.BeanUnproxy;
+import io.beanmapper.core.unproxy.UnproxyResultStore;
 import io.beanmapper.exceptions.BeanConversionException;
 import io.beanmapper.exceptions.BeanPropertyNoMatchException;
 import io.beanmapper.utils.BeanMapperTraceLogger;
@@ -65,8 +67,9 @@ public abstract class AbstractMapStrategy implements MapStrategy {
     }
 
     public <T, S> BeanMatch getBeanMatch(Class<S> sourceClazz, Class<T> targetClazz) {
-        Class<?> sourceClass = getConfiguration().getBeanUnproxy().unproxy(sourceClazz);
-        Class<?> targetClass = getConfiguration().getBeanUnproxy().unproxy(targetClazz);
+        BeanUnproxy unproxy = getConfiguration().getBeanUnproxy();
+        Class<?> sourceClass = UnproxyResultStore.getInstance().getOrComputeUnproxyResult(sourceClazz, unproxy);
+        Class<?> targetClass = UnproxyResultStore.getInstance().getOrComputeUnproxyResult(targetClazz, unproxy);
         return getConfiguration().getBeanMatchStore().getBeanMatch(
                 configuration.getStrictMappingProperties().createBeanPair(sourceClass, targetClass)
         );
@@ -131,7 +134,8 @@ public abstract class AbstractMapStrategy implements MapStrategy {
      */
     public Object convert(Object value, Class<?> targetClass, BeanPropertyMatch beanPropertyMatch) {
 
-        Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(beanPropertyMatch.getSourceClass());
+        BeanUnproxy unproxy = getConfiguration().getBeanUnproxy();
+        Class<?> valueClass = UnproxyResultStore.getInstance().getOrComputeUnproxyResult(beanPropertyMatch.getSourceClass(), unproxy);
         BeanConverter converter = getConverterOptional(valueClass, targetClass);
 
         if (converter != null) {

--- a/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToClassStrategy.java
@@ -4,6 +4,8 @@ import io.beanmapper.BeanMapper;
 import io.beanmapper.config.Configuration;
 import io.beanmapper.core.BeanMatch;
 import io.beanmapper.core.converter.BeanConverter;
+import io.beanmapper.core.unproxy.BeanUnproxy;
+import io.beanmapper.core.unproxy.UnproxyResultStore;
 import io.beanmapper.utils.BeanMapperTraceLogger;
 
 public class MapToClassStrategy extends MapToInstanceStrategy {
@@ -17,7 +19,8 @@ public class MapToClassStrategy extends MapToInstanceStrategy {
         Class<?> targetClass = getConfiguration().getTargetClass();
 
         if (getConfiguration().isConverterChoosable() || source instanceof Record) {
-            Class<?> valueClass = getConfiguration().getBeanUnproxy().unproxy(source.getClass());
+            BeanUnproxy unproxy = getConfiguration().getBeanUnproxy();
+            Class<?> valueClass = UnproxyResultStore.getInstance().getOrComputeUnproxyResult(source.getClass(), unproxy);
             BeanConverter converter = getConverterOptional(valueClass, targetClass);
             if (converter != null) {
                 BeanMapperTraceLogger.log("Converter called for source of class {}, while mapping to class {}\t{}->", source.getClass(), targetClass,

--- a/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
@@ -9,6 +9,8 @@ import io.beanmapper.utils.BeanMapperPerformanceLogger;
 
 public class MapToDynamicClassStrategy extends AbstractMapStrategy {
 
+    private static final String LOGGING_STRING = "Recursively calling BeanMapper#map(Object)";
+
     public MapToDynamicClassStrategy(BeanMapper beanMapper, Configuration configuration) {
         super(beanMapper, configuration);
     }
@@ -49,8 +51,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
         Class<?> targetClass = getConfiguration().getTargetClass();
         Object target = getConfiguration().getTarget();
 
-        Object dynSource = BeanMapperPerformanceLogger.runTimed("Recursively calling BeanMapper#map(Object), to map source of type %s, to target of type %s."
-                        .formatted(source.getClass().getCanonicalName(), dynamicClass.getCanonicalName()),
+        Object dynSource = BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
                 () -> getBeanMapper()
                         .wrap()
                         .downsizeSource(null)
@@ -59,8 +60,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
                         .build()
                         .map(source));
 
-        return BeanMapperPerformanceLogger.runTimed("Recursively calling BeanMapper#map(Object), to map source of type %s, to type %s."
-                        .formatted(dynSource.getClass().getCanonicalName(), targetClass != null ? targetClass.getCanonicalName() : "null"),
+        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
                 () -> getBeanMapper()
                         .wrap()
                         .downsizeSource(null)
@@ -76,8 +76,7 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
                 downsizeTargetFields,
                 getConfiguration().getStrictMappingProperties());
         Class<?> collectionClass = getBeanMapper().getConfiguration().getCollectionClass();
-        return BeanMapperPerformanceLogger.runTimed("Recursively calling BeanMapper#map(Object), to map source of type %s, to type %s."
-                .formatted(source.getClass().getCanonicalName(), dynamicClass.getCanonicalName()), () -> getBeanMapper()
+        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING, () -> getBeanMapper()
                 .wrap()
                 .downsizeTarget(null)
                 .setCollectionClass(collectionClass)

--- a/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
+++ b/src/main/java/io/beanmapper/strategy/MapToDynamicClassStrategy.java
@@ -9,7 +9,7 @@ import io.beanmapper.utils.BeanMapperPerformanceLogger;
 
 public class MapToDynamicClassStrategy extends AbstractMapStrategy {
 
-    private static final String LOGGING_STRING = "Recursively calling BeanMapper#map(Object)";
+    private static final String LOGGING_STRING = "Recursively calling BeanMapper#map(Object), to map source of type %s, to type %s.";
 
     public MapToDynamicClassStrategy(BeanMapper beanMapper, Configuration configuration) {
         super(beanMapper, configuration);
@@ -51,23 +51,21 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
         Class<?> targetClass = getConfiguration().getTargetClass();
         Object target = getConfiguration().getTarget();
 
-        Object dynSource = BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
-                () -> getBeanMapper()
+        Object dynSource = BeanMapperPerformanceLogger.runTimed(() -> getBeanMapper()
                         .wrap()
                         .downsizeSource(null)
                         .setTarget(target)
                         .setTargetClass(dynamicClass)
                         .build()
-                        .map(source));
+                        .map(source), LOGGING_STRING, source.getClass().getSimpleName(), targetClass != null ? targetClass.getSimpleName() : null);
 
-        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING,
-                () -> getBeanMapper()
+        return BeanMapperPerformanceLogger.runTimed(() -> getBeanMapper()
                         .wrap()
                         .downsizeSource(null)
                         .setTarget(target)
                         .setTargetClass(targetClass)
                         .build()
-                        .map(dynSource));
+                        .map(dynSource), LOGGING_STRING, dynSource.getClass().getSimpleName(), targetClass != null ? targetClass.getSimpleName() : null);
     }
 
     public <S, T> T downsizeTarget(S source, List<String> downsizeTargetFields) {
@@ -76,12 +74,12 @@ public class MapToDynamicClassStrategy extends AbstractMapStrategy {
                 downsizeTargetFields,
                 getConfiguration().getStrictMappingProperties());
         Class<?> collectionClass = getBeanMapper().getConfiguration().getCollectionClass();
-        return BeanMapperPerformanceLogger.runTimed(LOGGING_STRING, () -> getBeanMapper()
+        return BeanMapperPerformanceLogger.runTimed(() -> getBeanMapper()
                 .wrap()
                 .downsizeTarget(null)
                 .setCollectionClass(collectionClass)
                 .setTargetClass(dynamicClass)
                 .build()
-                .map(source));
+                .map(source), LOGGING_STRING, source.getClass().getSimpleName(), dynamicClass.getSimpleName());
     }
 }

--- a/src/main/java/io/beanmapper/utils/BeanMapperPerformanceLogger.java
+++ b/src/main/java/io/beanmapper/utils/BeanMapperPerformanceLogger.java
@@ -25,6 +25,14 @@ public class BeanMapperPerformanceLogger {
         return result;
     }
 
+    public static <T> T runTimed(Supplier<T> task, String unformattedTaskName, Object... messageArguments) {
+        if (log.isDebugEnabled()) {
+            String taskName = unformattedTaskName.formatted(messageArguments);
+            return runTimed(taskName, task);
+        }
+        return task.get();
+    }
+
     private static class Stopwatch {
 
         private final Instant started;


### PR DESCRIPTION
- Created UnproxyResultStore, allowing for caching of unproxied classes.
- Fixed the premature evaluation of String#formatted(Object ...), by only passing String literals to the performance logger.

Closes #196 #197 