### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,21 +52,22 @@
         <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <javassist.version>3.30.0-GA</javassist.version>
-        <slf4j.version>2.0.13</slf4j.version>
+        <javassist.version>3.30.2-GA</javassist.version>
+        <slf4j.version>2.0.16</slf4j.version>
 
-        <jackson-databind.version>2.17.0</jackson-databind.version>
-        <junit.version>5.10.3</junit.version>
+        <jackson-databind.version>2.18.1</jackson-databind.version>
+        <junit.version>5.11.3</junit.version>
+        <mockito-junit.version>5.14.2</mockito-junit.version>
 
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
-        <maven.release.plugin.version>3.0.1</maven.release.plugin.version>
-        <nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
+        <maven.surefire.plugin.version>3.5.1</maven.surefire.plugin.version>
+        <maven.release.plugin.version>3.1.1</maven.release.plugin.version>
+        <nexus.staging.plugin.version>1.7.0</nexus.staging.plugin.version>
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
-        <owasp.dependency.check.version>9.1.0</owasp.dependency.check.version>
-        <maven.javadoc.plugin.version>3.6.3</maven.javadoc.plugin.version>
+        <owasp.dependency.check.version>11.1.0</owasp.dependency.check.version>
+        <maven.javadoc.plugin.version>3.10.1</maven.javadoc.plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
-        <maven.gpg.plugin.version>3.2.3</maven.gpg.plugin.version>
+        <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
     </properties>
 
     <dependencies>
@@ -87,7 +88,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.11.0</version>
+            <version>${mockito-junit.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -180,7 +181,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${owasp.dependency.check.version}</version>
                 <configuration>
-                    <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                    <failBuildOnCVSS>0</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipTestScope>true</skipTestScope>
                     <skipRuntimeScope>true</skipRuntimeScope>


### PR DESCRIPTION
- Javassist 3.30.0 -> 3.30.2
- SLF4J 2.0.13 -> 2.0.16
- Jackson-Databind 2.17.0 -> 2.18.1
- JUnit 5.10.3 -> 5.11.3
- Mockito JUnit Jupiter 5.11.0 -> 5.14.2
- Surefire Plugin 3.2.5 -> 3.5.1
- Release Plugin 3.0.1 -> 3.1.1
- Nexus Staging Plugin 1.6.13 -> 1.7.0
- OWASP Dependency Check 9.1.0 -> 11.1.0
- Javadoc Plugin 3.6.3 -> 3.10.1
- GPG Plugin 3.2.3 -> 3.2.7